### PR TITLE
Add community issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a reproducible Bunpro MCP failure using sanitized information.
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Never include Bunpro credentials, cookies, frontend tokens, OAuth tokens, setup links, encryption keys, database URLs, or raw Bunpro responses.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the expected and actual behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - Local stdio
+        - Hosted Streamable HTTP
+        - Self-hosted Streamable HTTP
+    validations:
+      required: true
+  - type: input
+    id: client
+    attributes:
+      label: MCP client
+      description: For example, ChatGPT desktop, Codex CLI, or Claude Desktop.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Bunpro MCP commit or version
+      placeholder: 0.1.0 or a commit SHA
+    validations:
+      required: true
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: Required for local or self-hosted reports.
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest sequence that reproduces the problem without real account data.
+    validations:
+      required: true
+  - type: textarea
+    id: error
+    attributes:
+      label: Sanitized error
+      description: Remove all credentials, tokens, setup URLs, personal data, and raw response bodies.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety checks
+      options:
+        - label: I removed all secrets, personal data, setup links, and raw Bunpro responses.
+          required: true
+        - label: I searched existing issues and read the troubleshooting and security guidance.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/yash-278/bunpro-mcp/security/advisories/new
+    about: Never disclose credentials, tokens, setup links, or vulnerability details in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a focused, read-only Bunpro MCP capability.
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bunpro MCP is intentionally read-only. Requests that submit reviews, change progress, or modify a Bunpro account are out of scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: What should an MCP user be able to learn or verify?
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Example workflow
+      description: Give a realistic prompt and the result you would expect.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Read-only source evidence
+      description: If known, describe the Bunpro read surface without including raw personal responses.
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Accuracy and compatibility concerns
+      description: What must remain unavailable instead of being guessed?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Scope checks
+      options:
+        - label: This request is read-only and does not modify a Bunpro account.
+          required: true
+        - label: This issue contains no credentials, tokens, personal data, or raw Bunpro responses.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What changed
+
+Describe the focused change.
+
+## Why
+
+Explain the user problem or compatibility issue.
+
+## Safety and privacy
+
+- [ ] Bunpro interaction remains read-only.
+- [ ] No credentials, cookies, tokens, setup links, personal data, or raw Bunpro responses are included.
+- [ ] Tool schemas, annotations, and errors match the implemented behavior.
+- [ ] Privacy, security, or setup documentation was updated when behavior changed.
+
+## Verification
+
+- [ ] `npm run check` passes.
+- [ ] New or changed behavior has automated tests.
+- [ ] Any live test used only an authorized account and emitted sanitized output.


### PR DESCRIPTION
## What changed

- added a structured bug-report form with mandatory secret-redaction checks
- added a read-only feature-request form
- routed vulnerability reports to GitHub security advisories
- added a pull-request safety and verification checklist

## Why

The repository needs safe, consistent contribution intake before it is eventually opened to the Bunpro community.

## Verification

- all GitHub YAML files parse successfully
- `git diff --check` passed