### PR TITLE
Add source-backed Study Day summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ An unofficial, stateless, read-only Model Context Protocol (MCP) server for conn
 
 ## Project status
 
-The direct Account API Token connection is implemented. The date-bounded study-summary tool is still under development.
+The direct Account API Token connection and date-bounded study summaries are implemented.
 
-Available tool:
+Available tools:
 
 - `get_connection_status` verifies that the caller's Bunpro Account API Token can access Bunpro and returns the source timezone.
+- `get_study_day_summary` returns source-backed activity evidence for one exact Bunpro calendar day.
+- `get_study_range_summary` returns every inclusive calendar day in a bounded range using one upstream evidence fetch.
 
-The prioritized tool catalog and explicit non-goals are tracked in [docs/tool-roadmap.md](docs/tool-roadmap.md). The next implementation target is `get_study_day_summary`, followed by a bounded range variant for Atlas catch-up.
+The prioritized tool catalog and explicit non-goals are tracked in [docs/tool-roadmap.md](docs/tool-roadmap.md).
 
 All Bunpro requests are read-only. The server does not submit reviews, start lessons, change progress, or modify account settings.
 

--- a/docs/tool-roadmap.md
+++ b/docs/tool-roadmap.md
@@ -26,7 +26,7 @@ Answers: "Can this MCP access my Bunpro account?"
 - Output: authentication status, source timezone, token source, stateless/persistence guarantees
 - Request cost: 1 Bunpro request
 
-### `get_study_day_summary` — implement next
+### `get_study_day_summary` — implemented
 
 Answers: "What Bunpro study activity is supported for 2026-08-11?"
 
@@ -46,7 +46,7 @@ Answers: "What Bunpro study activity is supported for 2026-08-11?"
 
 The result must distinguish at least `complete`, `partial`, `no_source_record`, and `unavailable`. Study duration, exact correct/incorrect totals, and complete item history remain unavailable unless a future source proves them.
 
-### `get_study_range_summary` — implement with the day mapper
+### `get_study_range_summary` — implemented
 
 Answers: "Summarize every Bunpro study day from 2026-08-01 through 2026-08-11."
 

--- a/src/bunpro/client.ts
+++ b/src/bunpro/client.ts
@@ -95,8 +95,8 @@ export class BunproClient {
     this.#maximumResponseBytes = options.maximumResponseBytes ?? MAX_RESPONSE_BYTES;
   }
 
-  async checkConnection(): Promise<ConnectionStatus> {
-    const payload = await this.getFrontendJson("/api/frontend/user");
+  async checkConnection(operationSignal?: AbortSignal): Promise<ConnectionStatus> {
+    const payload = await this.getFrontendJson("/api/frontend/user", operationSignal);
     const userPayload = BunproUserResponseSchema.safeParse(payload);
     if (!userPayload.success) {
       throw new BunproError(
@@ -116,7 +116,7 @@ export class BunproClient {
     };
   }
 
-  async getFrontendJson(path: string): Promise<unknown> {
+  async getFrontendJson(path: string, operationSignal?: AbortSignal): Promise<unknown> {
     const url = new URL(path, API_ORIGIN);
     if (url.origin !== API_ORIGIN || !url.pathname.startsWith(FRONTEND_API_PREFIX)) {
       throw new BunproError(
@@ -128,6 +128,7 @@ export class BunproClient {
 
     const response = await this.#request(url, {
       method: "GET",
+      ...(operationSignal ? { signal: operationSignal } : {}),
       headers: {
         accept: "application/json",
         authorization: `Token token=${this.#apiToken}`,
@@ -173,9 +174,10 @@ export class BunproClient {
 
   async #request(url: URL, init: RequestInit): Promise<Response> {
     try {
+      const requestTimeout = AbortSignal.timeout(this.#requestTimeoutMs);
       const request = (): Promise<Response> => this.#fetch(url, {
         ...init,
-        signal: init.signal ?? AbortSignal.timeout(this.#requestTimeoutMs)
+        signal: init.signal ? AbortSignal.any([init.signal, requestTimeout]) : requestTimeout
       });
       return await (this.#requestGate ? this.#requestGate.run(request) : request());
     } catch (error) {

--- a/src/bunpro/client.ts
+++ b/src/bunpro/client.ts
@@ -173,11 +173,17 @@ export class BunproClient {
   }
 
   async #request(url: URL, init: RequestInit): Promise<Response> {
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(
+      () => timeoutController.abort(new DOMException("The Bunpro request timed out.", "TimeoutError")),
+      this.#requestTimeoutMs
+    );
     try {
-      const requestTimeout = AbortSignal.timeout(this.#requestTimeoutMs);
       const request = (): Promise<Response> => this.#fetch(url, {
         ...init,
-        signal: init.signal ? AbortSignal.any([init.signal, requestTimeout]) : requestTimeout
+        signal: init.signal
+          ? AbortSignal.any([init.signal, timeoutController.signal])
+          : timeoutController.signal
       });
       return await (this.#requestGate ? this.#requestGate.run(request) : request());
     } catch (error) {
@@ -188,6 +194,8 @@ export class BunproClient {
         "Bunpro could not be reached before the request timeout. Try again later.",
         { cause: error }
       );
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/src/bunpro/schemas.ts
+++ b/src/bunpro/schemas.ts
@@ -22,3 +22,103 @@ export const ConnectionStatusOutputSchema = z.object({
 
 export type ConnectionStatus = z.infer<typeof ConnectionStatusOutputSchema>;
 export type TokenSource = ConnectionStatus["token_source"];
+
+export const IsoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use an ISO date in YYYY-MM-DD format.");
+
+export const StudyDayInputSchema = z.object({
+  date: IsoDateSchema.describe("Bunpro calendar day in YYYY-MM-DD format."),
+  expected_timezone: z.string().min(1).optional().describe(
+    "Optional IANA timezone to compare with the Bunpro account timezone."
+  )
+}).strict();
+
+export const StudyRangeInputSchema = z.object({
+  start_date: IsoDateSchema.describe("First inclusive Bunpro calendar day."),
+  end_date: IsoDateSchema.describe("Last inclusive Bunpro calendar day, at most 93 days after the start."),
+  expected_timezone: z.string().min(1).optional().describe(
+    "Optional IANA timezone to compare with the Bunpro account timezone."
+  )
+}).strict();
+
+export const DailyCountEvidenceSchema = z.object({
+  coverage: z.enum(["available", "no_source_record", "unavailable"]),
+  grammar: z.number().int().nonnegative().nullable(),
+  vocabulary: z.number().int().nonnegative().nullable(),
+  source_total: z.number().int().nonnegative().nullable(),
+  component_sum: z.number().int().nonnegative().nullable(),
+  consistency: z.enum(["match", "mismatch", "not_comparable"])
+});
+
+export const AccuracyEvidenceSchema = z.object({
+  coverage: z.enum(["available", "no_source_record", "unavailable"]),
+  percent: z.number().nullable()
+});
+
+export const SourceCoverageSchema = z.object({
+  status: z.enum(["available", "contract_changed", "rate_limited", "upstream_unavailable", "not_queried"]),
+  first_record_date: IsoDateSchema.nullable(),
+  last_record_date: IsoDateSchema.nullable()
+});
+
+export const StudyDayEvidenceSchema = z.object({
+  study_day: IsoDateSchema,
+  in_progress: z.boolean(),
+  activity_evidence: z.enum(["recorded", "no_source_record", "unavailable"]),
+  reviews: DailyCountEvidenceSchema,
+  new_content: DailyCountEvidenceSchema,
+  accuracy: AccuracyEvidenceSchema
+});
+
+export const StudyDaySummaryOutputSchema = StudyDayEvidenceSchema.extend({
+  source_timezone: z.string().min(1),
+  expected_timezone: z.string().min(1).nullable(),
+  timezone_matches: z.boolean().nullable(),
+  overall_query_status: z.enum(["complete", "partial"]),
+  source_coverage: z.object({
+    reviews: SourceCoverageSchema,
+    new_content: SourceCoverageSchema,
+    accuracy: SourceCoverageSchema
+  }),
+  unavailable_measures: z.array(z.string())
+});
+
+export const StudyRangeSummaryOutputSchema = z.object({
+  requested_start_date: IsoDateSchema,
+  requested_end_date: IsoDateSchema,
+  source_timezone: z.string().min(1),
+  expected_timezone: z.string().min(1).nullable(),
+  timezone_matches: z.boolean().nullable(),
+  overall_query_status: z.enum(["complete", "partial"]),
+  days: z.array(StudyDayEvidenceSchema).max(93),
+  aggregates: z.object({
+    reviews: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      source_total: z.number().int().nonnegative()
+    }),
+    new_content: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      source_total: z.number().int().nonnegative()
+    }),
+    accuracy: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      average_percent: z.number().nullable()
+    })
+  }),
+  contiguous_checked_through: z.object({
+    activity: IsoDateSchema.nullable(),
+    accuracy: IsoDateSchema.nullable(),
+    all_sources: IsoDateSchema.nullable()
+  }),
+  source_coverage: z.object({
+    reviews: SourceCoverageSchema,
+    new_content: SourceCoverageSchema,
+    accuracy: SourceCoverageSchema
+  }),
+  unavailable_measures: z.array(z.string())
+});
+
+export type StudyDayInput = z.infer<typeof StudyDayInputSchema>;
+export type StudyDaySummary = z.infer<typeof StudyDaySummaryOutputSchema>;
+export type StudyDayEvidence = z.infer<typeof StudyDayEvidenceSchema>;
+export type StudyRangeInput = z.infer<typeof StudyRangeInputSchema>;
+export type StudyRangeSummary = z.infer<typeof StudyRangeSummaryOutputSchema>;

--- a/src/bunpro/study.ts
+++ b/src/bunpro/study.ts
@@ -1,0 +1,353 @@
+import * as z from "zod/v4";
+import { BunproError } from "./errors.js";
+import type {
+  ConnectionStatus,
+  StudyDayEvidence,
+  StudyDayInput,
+  StudyDaySummary,
+  StudyRangeInput,
+  StudyRangeSummary
+} from "./schemas.js";
+
+const REVIEW_HEATMAP_ROUTE = "/api/frontend/user_stats/review_heatmap";
+const NEW_CONTENT_HEATMAP_ROUTE = "/api/frontend/user_stats/new_content_heatmap";
+const ACCURACY_ROUTE = "/api/frontend/user_stats/accuracy_over_time";
+
+const DailyCountMapSchema = z.record(z.string(), z.number().int().nonnegative());
+const HeatmapSchema = z.object({
+  grammar: DailyCountMapSchema,
+  vocab: DailyCountMapSchema,
+  mixed: DailyCountMapSchema
+});
+const AccuracyMapSchema = z.record(z.string(), z.number().nullable());
+type SourceStatus = StudyDaySummary["source_coverage"]["reviews"]["status"];
+
+type SourceResult<T> =
+  | { status: "available"; data: T }
+  | { status: Exclude<SourceStatus, "available"> };
+
+export interface StudySource {
+  checkConnection(operationSignal?: AbortSignal): Promise<ConnectionStatus>;
+  getFrontendJson(path: string, operationSignal?: AbortSignal): Promise<unknown>;
+}
+
+interface LoadedEvidence {
+  connection: ConnectionStatus;
+  reviews: SourceResult<z.infer<typeof HeatmapSchema>>;
+  newContent: SourceResult<z.infer<typeof HeatmapSchema>>;
+  accuracy: SourceResult<z.infer<typeof AccuracyMapSchema>>;
+}
+
+const UNAVAILABLE_MEASURES = [
+  "study duration for the requested day",
+  "exact correct and incorrect counts for the requested day",
+  "complete item-level history for an arbitrary historical day"
+];
+
+export async function getStudyDaySummary(
+  source: StudySource,
+  input: StudyDayInput,
+  now: Date = new Date()
+): Promise<StudyDaySummary> {
+  assertValidCalendarDate(input.date);
+  const operationSignal = AbortSignal.timeout(30_000);
+  const connection = await source.checkConnection(operationSignal);
+  const currentDate = dateInTimeZone(now, connection.source_timezone);
+  if (input.date > currentDate) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Study Day cannot be in the future.");
+  }
+  const evidence = await loadEvidence(source, connection, operationSignal);
+  const day = buildDayEvidence(evidence, input.date, currentDate);
+
+  return {
+    ...day,
+    source_timezone: evidence.connection.source_timezone,
+    expected_timezone: input.expected_timezone ?? null,
+    timezone_matches: input.expected_timezone === undefined
+      ? null
+      : input.expected_timezone === evidence.connection.source_timezone,
+    overall_query_status: overallStatus(evidence),
+    source_coverage: sourceCoverage(evidence),
+    unavailable_measures: UNAVAILABLE_MEASURES
+  };
+}
+
+export async function getStudyRangeSummary(
+  source: StudySource,
+  input: StudyRangeInput,
+  now: Date = new Date()
+): Promise<StudyRangeSummary> {
+  const dates = inclusiveDates(input.start_date, input.end_date);
+  if (dates.length > 93) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Study ranges may include at most 93 calendar days.");
+  }
+  const operationSignal = AbortSignal.timeout(30_000);
+  const connection = await source.checkConnection(operationSignal);
+  const currentDate = dateInTimeZone(now, connection.source_timezone);
+  if (input.end_date > currentDate) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Study range cannot end in the future.");
+  }
+  const evidence = await loadEvidence(source, connection, operationSignal);
+  const days = dates.map(date => buildDayEvidence(evidence, date, currentDate));
+  const reviewDays = days.filter(day => day.reviews.coverage === "available");
+  const newContentDays = days.filter(day => day.new_content.coverage === "available");
+  const accuracyDays = days.filter(day => day.accuracy.coverage === "available" && day.accuracy.percent !== null);
+  const accuracyTotal = accuracyDays.reduce((total, day) => total + (day.accuracy.percent ?? 0), 0);
+  const activityChecked = evidence.reviews.status === "available" && evidence.newContent.status === "available";
+  const accuracyChecked = evidence.accuracy.status === "available";
+
+  return {
+    requested_start_date: input.start_date,
+    requested_end_date: input.end_date,
+    source_timezone: evidence.connection.source_timezone,
+    expected_timezone: input.expected_timezone ?? null,
+    timezone_matches: input.expected_timezone === undefined
+      ? null
+      : input.expected_timezone === evidence.connection.source_timezone,
+    overall_query_status: overallStatus(evidence),
+    days,
+    aggregates: {
+      reviews: {
+        source_record_days: reviewDays.length,
+        source_total: reviewDays.reduce((total, day) => total + (day.reviews.source_total ?? 0), 0)
+      },
+      new_content: {
+        source_record_days: newContentDays.length,
+        source_total: newContentDays.reduce((total, day) => total + (day.new_content.source_total ?? 0), 0)
+      },
+      accuracy: {
+        source_record_days: accuracyDays.length,
+        average_percent: accuracyDays.length === 0 ? null : accuracyTotal / accuracyDays.length
+      }
+    },
+    contiguous_checked_through: {
+      activity: activityChecked ? input.end_date : null,
+      accuracy: accuracyChecked ? input.end_date : null,
+      all_sources: activityChecked && accuracyChecked ? input.end_date : null
+    },
+    source_coverage: sourceCoverage(evidence),
+    unavailable_measures: UNAVAILABLE_MEASURES
+  };
+}
+
+async function loadEvidence(
+  source: StudySource,
+  connection: ConnectionStatus,
+  operationSignal: AbortSignal
+): Promise<LoadedEvidence> {
+  const reviews = await fetchSource(
+    source,
+    REVIEW_HEATMAP_ROUTE,
+    HeatmapSchema,
+    "review heatmap",
+    operationSignal
+  );
+  const newContent = reviews.status === "rate_limited"
+    ? { status: "not_queried" } as const
+    : await fetchSource(
+      source,
+      NEW_CONTENT_HEATMAP_ROUTE,
+      HeatmapSchema,
+      "new-content heatmap",
+      operationSignal
+    );
+  const accuracy = reviews.status === "rate_limited" || newContent.status === "rate_limited"
+    ? { status: "not_queried" } as const
+    : await fetchSource(source, ACCURACY_ROUTE, AccuracyMapSchema, "accuracy history", operationSignal);
+  if (![reviews, newContent, accuracy].some(result => result.status === "available")) {
+    if ([reviews, newContent, accuracy].some(result => result.status === "rate_limited")) {
+      throw new BunproError(
+        "BUNPRO_RATE_LIMITED",
+        "Bunpro rate-limited the Study Day request. Wait before trying again."
+      );
+    }
+    if ([reviews, newContent, accuracy].every(
+      result => result.status === "contract_changed" || result.status === "not_queried"
+    )) {
+      throw new BunproError(
+        "BUNPRO_CONTRACT_CHANGED",
+        "Bunpro authentication succeeded, but the Study Day source contracts are unavailable."
+      );
+    }
+    throw new BunproError(
+      "BUNPRO_UPSTREAM_UNAVAILABLE",
+      "Bunpro authentication succeeded, but no requested Study Day source was available."
+    );
+  }
+  return { connection, reviews, newContent, accuracy };
+}
+
+function buildDayEvidence(evidence: LoadedEvidence, date: string, currentDate: string): StudyDayEvidence {
+  const reviews = evidence.reviews.status === "available"
+    ? countEvidence(evidence.reviews.data, date)
+    : unavailableCountEvidence();
+  const newContent = evidence.newContent.status === "available"
+    ? countEvidence(evidence.newContent.data, date)
+    : unavailableCountEvidence();
+  const activityRecorded = reviews.coverage === "available" || newContent.coverage === "available";
+  const activitySourcesAvailable = evidence.reviews.status === "available" &&
+    evidence.newContent.status === "available";
+  return {
+    study_day: date,
+    in_progress: date === currentDate,
+    activity_evidence: activityRecorded
+      ? "recorded"
+      : activitySourcesAvailable ? "no_source_record" : "unavailable",
+    reviews,
+    new_content: newContent,
+    accuracy: evidence.accuracy.status !== "available"
+      ? { coverage: "unavailable", percent: null }
+      : Object.hasOwn(evidence.accuracy.data, date)
+        ? { coverage: "available", percent: evidence.accuracy.data[date] ?? null }
+        : { coverage: "no_source_record", percent: null }
+  };
+}
+
+function overallStatus(evidence: LoadedEvidence): StudyDaySummary["overall_query_status"] {
+  return [evidence.reviews, evidence.newContent, evidence.accuracy].every(
+    result => result.status === "available"
+  ) ? "complete" : "partial";
+}
+
+function sourceCoverage(evidence: LoadedEvidence): StudyDaySummary["source_coverage"] {
+  return {
+    reviews: coverageForSource(evidence.reviews),
+    new_content: coverageForSource(evidence.newContent),
+    accuracy: coverageForSource(evidence.accuracy)
+  };
+}
+
+async function fetchSource<T>(
+  source: StudySource,
+  route: string,
+  schema: z.ZodType<T>,
+  name: string,
+  operationSignal: AbortSignal
+): Promise<SourceResult<T>> {
+  try {
+    return {
+      status: "available",
+      data: parseSource(schema, await source.getFrontendJson(route, operationSignal), name)
+    };
+  } catch (error) {
+    if (!(error instanceof BunproError)) throw error;
+    if (error.code === "BUNPRO_AUTH_FAILED" || error.code === "BUNPRO_BUSY") throw error;
+    if (error.code === "BUNPRO_RATE_LIMITED") return { status: "rate_limited" };
+    if (error.code === "BUNPRO_CONTRACT_CHANGED") return { status: "contract_changed" };
+    return { status: "upstream_unavailable" };
+  }
+}
+
+function parseSource<T>(schema: z.ZodType<T>, payload: unknown, name: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new BunproError(
+      "BUNPRO_CONTRACT_CHANGED",
+      `Bunpro accepted the Account API Token, but the ${name} response shape changed.`
+    );
+  }
+  return parsed.data;
+}
+
+function countEvidence(payload: z.infer<typeof HeatmapSchema>, date: string): StudyDaySummary["reviews"] {
+  const sourceRecordPresent = Object.hasOwn(payload.mixed, date);
+  if (!sourceRecordPresent) {
+    return {
+      coverage: "no_source_record",
+      grammar: null,
+      vocabulary: null,
+      source_total: null,
+      component_sum: null,
+      consistency: "not_comparable"
+    };
+  }
+  const grammar = payload.grammar[date] ?? null;
+  const vocabulary = payload.vocab[date] ?? null;
+  const sourceTotal = payload.mixed[date] ?? 0;
+  const componentSum = grammar === null || vocabulary === null ? null : grammar + vocabulary;
+  return {
+    coverage: "available",
+    grammar,
+    vocabulary,
+    source_total: sourceTotal,
+    component_sum: componentSum,
+    consistency: componentSum === null ? "not_comparable" : sourceTotal === componentSum ? "match" : "mismatch"
+  };
+}
+
+function unavailableCountEvidence(): StudyDaySummary["reviews"] {
+  return {
+    coverage: "unavailable",
+    grammar: null,
+    vocabulary: null,
+    source_total: null,
+    component_sum: null,
+    consistency: "not_comparable"
+  };
+}
+
+function coverageForSource<T>(result: SourceResult<T>): StudyDaySummary["source_coverage"]["reviews"] {
+  if (result.status !== "available") {
+    return { status: result.status, first_record_date: null, last_record_date: null };
+  }
+  if (!isRecord(result.data)) {
+    return { status: "contract_changed", first_record_date: null, last_record_date: null };
+  }
+  return coverageForMap(result.data);
+}
+
+function coverageForMap(payload: Record<string, unknown>): StudyDaySummary["source_coverage"]["reviews"] {
+  const dates = collectIsoDates(payload);
+  return {
+    status: "available",
+    first_record_date: dates[0] ?? null,
+    last_record_date: dates.at(-1) ?? null
+  };
+}
+
+function collectIsoDates(payload: Record<string, unknown>): string[] {
+  const candidates = Object.values(payload).every(value => isRecord(value))
+    ? Object.values(payload).flatMap(value => Object.keys(value as Record<string, unknown>))
+    : Object.keys(payload);
+  return [...new Set(candidates.filter(value => /^\d{4}-\d{2}-\d{2}$/.test(value)))].sort();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertValidCalendarDate(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Use an ISO date in YYYY-MM-DD format.");
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Study Day is not a valid calendar date.");
+  }
+}
+
+function inclusiveDates(start: string, end: string): string[] {
+  assertValidCalendarDate(start);
+  assertValidCalendarDate(end);
+  if (start > end) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Study range start_date must not follow end_date.");
+  }
+  const dates: string[] = [];
+  const cursor = new Date(`${start}T00:00:00Z`);
+  const endValue = new Date(`${end}T00:00:00Z`).valueOf();
+  while (cursor.valueOf() <= endValue && dates.length <= 93) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  if (cursor.valueOf() <= endValue) dates.push(cursor.toISOString().slice(0, 10));
+  return dates;
+}
+
+function dateInTimeZone(value: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(value);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,9 +3,17 @@ import * as z from "zod/v4";
 import { BunproClient, apiTokenFromEnvironment } from "./bunpro/client.js";
 import { connectionErrorMessage } from "./bunpro/errors.js";
 import { ConnectionStatusOutputSchema, type ConnectionStatus } from "./bunpro/schemas.js";
+import {
+  StudyDayInputSchema,
+  StudyDaySummaryOutputSchema,
+  StudyRangeInputSchema,
+  StudyRangeSummaryOutputSchema
+} from "./bunpro/schemas.js";
+import { getStudyDaySummary, getStudyRangeSummary } from "./bunpro/study.js";
 
 export interface BunproAccountAccess {
-  checkConnection(): Promise<ConnectionStatus>;
+  checkConnection(operationSignal?: AbortSignal): Promise<ConnectionStatus>;
+  getFrontendJson(path: string, operationSignal?: AbortSignal): Promise<unknown>;
 }
 
 export type BunproClientFactory = () => BunproAccountAccess;
@@ -38,6 +46,68 @@ export function createServer(
     async (): Promise<CallToolResult> => {
       try {
         const structuredContent = await getClient().checkConnection();
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_study_day_summary",
+    {
+      title: "Get Bunpro Study Day summary",
+      description:
+        "Return source-backed Bunpro review, new-content, and accuracy evidence for one exact Bunpro calendar day. Missing sparse records remain unknown rather than zero.",
+      inputSchema: StudyDayInputSchema,
+      outputSchema: StudyDaySummaryOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async input => {
+      try {
+        const structuredContent = await getStudyDaySummary(getClient(), input);
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_study_range_summary",
+    {
+      title: "Get Bunpro Study range summary",
+      description:
+        "Return one source-backed entry for every inclusive Bunpro calendar day in a range of at most 93 days, using one bounded set of upstream requests.",
+      inputSchema: StudyRangeInputSchema,
+      outputSchema: StudyRangeSummaryOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async input => {
+      try {
+        const structuredContent = await getStudyRangeSummary(getClient(), input);
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent

--- a/tests/study-tools.test.ts
+++ b/tests/study-tools.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/client";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createHttpMcpHandler } from "../src/http-server.js";
+import type { FetchLike } from "../src/bunpro/client.js";
+
+const fixtures: Record<string, unknown> = {
+  "/api/frontend/user": {
+    user: { data: { attributes: { time_zone_iana: "Asia/Kolkata" } } }
+  },
+  "/api/frontend/user_stats/review_heatmap": {
+    grammar: { "2026-08-10": 3, "2026-08-11": 4 },
+    vocab: { "2026-08-10": 2 },
+    mixed: { "2026-08-10": 6, "2026-08-11": 4 }
+  },
+  "/api/frontend/user_stats/new_content_heatmap": {
+    grammar: { "2026-08-10": 1 },
+    vocab: { "2026-08-10": 2 },
+    mixed: { "2026-08-10": 3 }
+  },
+  "/api/frontend/user_stats/accuracy_over_time": {
+    "2026-08-10": 88.5
+  }
+};
+
+async function withMcpClient(
+  fetchImplementation: FetchLike,
+  run: (client: Client) => Promise<void>
+): Promise<void> {
+  const handler = createHttpMcpHandler(fetchImplementation);
+  const transport = new StreamableHTTPClientTransport(new URL("https://mcp.example/mcp"), {
+    authProvider: { token: async () => "account-token" },
+    fetch: (input, init) => handler.fetch(new Request(input, init))
+  });
+  const client = new Client({ name: "study-tools-test", version: "0.1.0" });
+  try {
+    await client.connect(transport);
+    await run(client);
+  } finally {
+    await client.close();
+    await handler.close();
+  }
+}
+
+function fixtureFetch(requestedPaths: string[]): FetchLike {
+  return async input => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    requestedPaths.push(url.pathname);
+    const body = fixtures[url.pathname];
+    return body === undefined
+      ? new Response("not found", { status: 404 })
+      : Response.json(body);
+  };
+}
+
+test("get_study_day_summary returns normalized source-backed evidence after authenticating first", async () => {
+  const requestedPaths: string[] = [];
+  await withMcpClient(fixtureFetch(requestedPaths), async client => {
+    const result = await client.callTool({
+      name: "get_study_day_summary",
+      arguments: { date: "2026-08-10", expected_timezone: "Asia/Kolkata" }
+    });
+
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.equal(output.study_day, "2026-08-10");
+    assert.equal(output.source_timezone, "Asia/Kolkata");
+    assert.equal(output.timezone_matches, true);
+    assert.equal(output.in_progress, false);
+    assert.equal(output.overall_query_status, "complete");
+    assert.deepEqual(output.reviews, {
+      coverage: "available",
+      grammar: 3,
+      vocabulary: 2,
+      source_total: 6,
+      component_sum: 5,
+      consistency: "mismatch"
+    });
+    assert.deepEqual(output.new_content, {
+      coverage: "available",
+      grammar: 1,
+      vocabulary: 2,
+      source_total: 3,
+      component_sum: 3,
+      consistency: "match"
+    });
+    assert.deepEqual(output.accuracy, { coverage: "available", percent: 88.5 });
+    assert.equal(output.activity_evidence, "recorded");
+    assert.deepEqual(requestedPaths, [
+      "/api/frontend/user",
+      "/api/frontend/user_stats/review_heatmap",
+      "/api/frontend/user_stats/new_content_heatmap",
+      "/api/frontend/user_stats/accuracy_over_time"
+    ]);
+  });
+});
+
+test("get_study_day_summary preserves activity evidence when accuracy coverage is unavailable", async () => {
+  const requestedPaths: string[] = [];
+  const partialFetch: FetchLike = async input => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    requestedPaths.push(url.pathname);
+    if (url.pathname === "/api/frontend/user_stats/accuracy_over_time") {
+      return new Response("route unavailable", { status: 404 });
+    }
+    const body = fixtures[url.pathname];
+    return body === undefined ? new Response("not found", { status: 404 }) : Response.json(body);
+  };
+
+  await withMcpClient(partialFetch, async client => {
+    const result = await client.callTool({
+      name: "get_study_day_summary",
+      arguments: { date: "2026-08-10" }
+    });
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.equal(output.overall_query_status, "partial");
+    assert.equal(output.activity_evidence, "recorded");
+    assert.deepEqual(output.accuracy, { coverage: "unavailable", percent: null });
+    assert.deepEqual(output.source_coverage.accuracy, {
+      status: "contract_changed",
+      first_record_date: null,
+      last_record_date: null
+    });
+    assert.equal(requestedPaths.length, 4);
+  });
+});
+
+test("get_study_range_summary fetches each source once and returns every requested calendar day", async () => {
+  const requestedPaths: string[] = [];
+  await withMcpClient(fixtureFetch(requestedPaths), async client => {
+    const result = await client.callTool({
+      name: "get_study_range_summary",
+      arguments: {
+        start_date: "2026-08-10",
+        end_date: "2026-08-12",
+        expected_timezone: "Asia/Kolkata"
+      }
+    });
+
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.equal(output.requested_start_date, "2026-08-10");
+    assert.equal(output.requested_end_date, "2026-08-12");
+    assert.deepEqual(output.days.map((day: any) => day.study_day), [
+      "2026-08-10",
+      "2026-08-11",
+      "2026-08-12"
+    ]);
+    assert.equal(output.days[2].activity_evidence, "no_source_record");
+    assert.deepEqual(output.aggregates, {
+      reviews: { source_record_days: 2, source_total: 10 },
+      new_content: { source_record_days: 1, source_total: 3 },
+      accuracy: { source_record_days: 1, average_percent: 88.5 }
+    });
+    assert.deepEqual(output.contiguous_checked_through, {
+      activity: "2026-08-12",
+      accuracy: "2026-08-12",
+      all_sources: "2026-08-12"
+    });
+    assert.deepEqual(requestedPaths, [
+      "/api/frontend/user",
+      "/api/frontend/user_stats/review_heatmap",
+      "/api/frontend/user_stats/new_content_heatmap",
+      "/api/frontend/user_stats/accuracy_over_time"
+    ]);
+  });
+});
+
+test("study tools reject invalid and oversized ranges before making Bunpro requests", async () => {
+  let calls = 0;
+  const countingFetch: FetchLike = async () => {
+    calls += 1;
+    return Response.json(fixtures["/api/frontend/user"]);
+  };
+  await withMcpClient(countingFetch, async client => {
+    const invalidDay = await client.callTool({
+      name: "get_study_day_summary",
+      arguments: { date: "2026-02-30" }
+    });
+    assert.equal(invalidDay.isError, true);
+
+    const reversed = await client.callTool({
+      name: "get_study_range_summary",
+      arguments: { start_date: "2026-08-10", end_date: "2026-08-09" }
+    });
+    assert.equal(reversed.isError, true);
+
+    const tooLong = await client.callTool({
+      name: "get_study_range_summary",
+      arguments: { start_date: "2026-01-01", end_date: "2026-04-04" }
+    });
+    assert.equal(tooLong.isError, true);
+    assert.equal(calls, 0);
+  });
+});
+
+test("a rate limit on the first Study Day source stops the operation without fan-out", async () => {
+  const requestedPaths: string[] = [];
+  const throttledFetch: FetchLike = async input => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    requestedPaths.push(url.pathname);
+    if (url.pathname === "/api/frontend/user") return Response.json(fixtures[url.pathname]);
+    return new Response("slow down", { status: 429 });
+  };
+  await withMcpClient(throttledFetch, async client => {
+    const result = await client.callTool({
+      name: "get_study_day_summary",
+      arguments: { date: "2026-08-10" }
+    });
+    assert.equal(result.isError, true);
+    assert.match((result.content[0] as { text: string }).text, /^BUNPRO_RATE_LIMITED:/);
+    assert.deepEqual(requestedPaths, [
+      "/api/frontend/user",
+      "/api/frontend/user_stats/review_heatmap"
+    ]);
+  });
+});
+
+test("future Study Days stop after the timezone authentication request", async () => {
+  const requestedPaths: string[] = [];
+  await withMcpClient(fixtureFetch(requestedPaths), async client => {
+    const result = await client.callTool({
+      name: "get_study_day_summary",
+      arguments: { date: "2999-01-01" }
+    });
+    assert.equal(result.isError, true);
+    assert.deepEqual(requestedPaths, ["/api/frontend/user"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add exact-day and bounded 93-day range tools
- authenticate once, fetch each evidence source once, and stop fan-out on throttling
- preserve sparse missing records as unknown rather than zero
- report independent activity/accuracy coverage, mismatched totals, source windows, and contiguous checked-through dates
- enforce Bunpro-timezone future-date boundaries and a 30-second operation deadline

## Verification
- MCP-interface synthetic contract tests for complete, partial, invalid, future, and throttled cases
- existing client and HTTP passthrough tests
- TypeScript typecheck and production build
- secret scan and git diff check