### PR TITLE
Add review planning and recent activity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Available tools:
 - `get_connection_status` verifies that the caller's Bunpro Account API Token can access Bunpro and returns the source timezone.
 - `get_study_day_summary` returns source-backed activity evidence for one exact Bunpro calendar day.
 - `get_study_range_summary` returns every inclusive calendar day in a bounded range using one upstream evidence fetch.
+- `get_review_schedule` returns reviews due now and Bunpro's current daily forecast.
+- `list_study_decks` returns bounded active study-deck goals and completion counts.
+- `get_recent_activity` returns a bounded last-24-hours or latest-attempts view.
 
 The prioritized tool catalog and explicit non-goals are tracked in [docs/tool-roadmap.md](docs/tool-roadmap.md).
 

--- a/docs/tool-roadmap.md
+++ b/docs/tool-roadmap.md
@@ -65,7 +65,7 @@ This is a separate tool because it makes catch-up cheap and prevents an agent fr
 
 These tools are useful to people directly, but they are not required for the first Atlas ingestion milestone. Their routes were successful in the earlier authenticated Frontend API inventory; Account API Token access and current response schemas must be revalidated with one low-volume probe per route before implementation.
 
-### `get_review_schedule`
+### `get_review_schedule` — implemented
 
 Answers: "How many reviews are due now, and what does the next week look like?"
 
@@ -74,7 +74,7 @@ Answers: "How many reviews are due now, and what does the next week look like?"
 - Output: due-now summary, daily forecast buckets, source timezone, generated-at time, and coverage
 - Important boundary: forecast values are projections, not completed study activity
 
-### `list_study_decks`
+### `list_study_decks` — implemented
 
 Answers: "Which Bunpro study decks are active, and what are their goals and completion counts?"
 
@@ -83,7 +83,7 @@ Answers: "Which Bunpro study decks are active, and what are their goals and comp
 - Output: bounded deck identity, active status, batch size, daily goals, and grammar/vocabulary completion counts plus `count` and `has_more`
 - Important boundary: never describe these records as queued review items or return an unbounded raw payload
 
-### `get_recent_activity`
+### `get_recent_activity` — implemented
 
 Answers: "What did I review recently?" or "What happened in the last 24 hours?"
 

--- a/src/bunpro/planning.ts
+++ b/src/bunpro/planning.ts
@@ -1,0 +1,275 @@
+import * as z from "zod/v4";
+import { BunproError } from "./errors.js";
+import type {
+  ListStudyDecksInput,
+  ListStudyDecksOutput,
+  RecentActivityInput,
+  RecentActivityOutput,
+  ReviewSchedule
+} from "./schemas.js";
+import type { StudySource } from "./study.js";
+
+const DUE_ROUTE = "/api/frontend/user/due";
+const FORECAST_ROUTE = "/api/frontend/user_stats/forecast_daily";
+const STUDY_DECKS_ROUTE = "/api/frontend/user/queue";
+const LATEST_ATTEMPTS_ROUTE = "/api/frontend/user_stats/last_done_reviews";
+const LAST_24_HOURS_ROUTE = "/api/frontend/summary/last_24_hours";
+
+const DueSchema = z.object({
+  total_due_grammar: z.number().int().nonnegative(),
+  total_due_vocab: z.number().int().nonnegative()
+}).loose();
+const ForecastMapSchema = z.record(z.string(), z.number().int().nonnegative());
+const ForecastSchema = z.object({
+  grammar: ForecastMapSchema,
+  vocab: ForecastMapSchema
+});
+const UserDeckSchema = z.object({
+  id: z.string(),
+  attributes: z.object({
+    deck_id: z.number().int().nonnegative(),
+    actively_studying: z.boolean(),
+    batch_size: z.number().int().nonnegative(),
+    daily_goal: z.number().int().nonnegative(),
+    daily_goal_count_grammar: z.number().int().nonnegative(),
+    daily_goal_count_vocab: z.number().int().nonnegative(),
+    complete_grammar_count: z.number().int().nonnegative(),
+    complete_vocab_count: z.number().int().nonnegative()
+  }).loose()
+}).loose();
+const DeckMetadataSchema = z.object({
+  id: z.string(),
+  attributes: z.object({
+    title: z.string(),
+    slug: z.string(),
+    deck_type: z.string(),
+    grammar_count: z.number().int().nonnegative(),
+    vocab_count: z.number().int().nonnegative()
+  }).loose()
+}).loose();
+const StudyDeckQueueSchema = z.object({
+  data: z.array(UserDeckSchema),
+  included: z.array(DeckMetadataSchema)
+});
+const AttemptSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  time: z.string().min(1),
+  status: z.boolean(),
+  reviewable: z.object({
+    data: z.object({
+      id: z.union([z.string(), z.number()]),
+      type: z.string().min(1),
+      attributes: z.object({
+        title: z.string().optional(),
+        slug: z.string().optional()
+      }).loose()
+    }).loose()
+  }).loose()
+}).loose();
+const ReviewSessionSchema = z.object({
+  attributes: z.object({
+    starting_xp: z.number().int(),
+    ending_xp: z.number().int(),
+    starting_buncoin: z.number().int(),
+    ending_buncoin: z.number().int()
+  }).loose()
+}).loose();
+const Last24HoursSchema = z.object({
+  history_objects: z.array(AttemptSchema),
+  review_sessions: z.object({ data: z.array(ReviewSessionSchema) }).loose()
+}).loose();
+const LatestAttemptsSchema = z.array(AttemptSchema);
+
+export async function getReviewSchedule(
+  source: StudySource,
+  now: Date = new Date()
+): Promise<ReviewSchedule> {
+  const operationSignal = AbortSignal.timeout(30_000);
+  const connection = await source.checkConnection(operationSignal);
+  const due = parse(DueSchema, await source.getFrontendJson(DUE_ROUTE, operationSignal), "due counts");
+  const forecast = parse(
+    ForecastSchema,
+    await source.getFrontendJson(FORECAST_ROUTE, operationSignal),
+    "daily forecast"
+  );
+  const grammarKeys = Object.keys(forecast.grammar).sort();
+  const vocabularyKeys = Object.keys(forecast.vocab).sort();
+  if (grammarKeys.join("\0") !== vocabularyKeys.join("\0")) {
+    throw new BunproError(
+      "BUNPRO_CONTRACT_CHANGED",
+      "Bunpro returned inconsistent grammar and vocabulary forecast buckets."
+    );
+  }
+  const today = dateInTimeZone(now, connection.source_timezone);
+  const tomorrow = addDays(today, 1);
+  const keys = ["later", "tomorrow", ...grammarKeys.filter(key => key !== "later" && key !== "tomorrow").sort()];
+  if (keys.length > 14 || !Object.hasOwn(forecast.grammar, "later") || !Object.hasOwn(forecast.grammar, "tomorrow")) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Bunpro returned an unexpected daily forecast horizon.");
+  }
+
+  return {
+    source_timezone: connection.source_timezone,
+    retrieved_at: now.toISOString(),
+    due_now: {
+      grammar: due.total_due_grammar,
+      vocabulary: due.total_due_vocab,
+      total: due.total_due_grammar + due.total_due_vocab
+    },
+    forecast: keys.map(key => {
+      const grammar = forecast.grammar[key] ?? 0;
+      const vocabulary = forecast.vocab[key] ?? 0;
+      return {
+        bucket: key === "later" ? "later_today" : key === "tomorrow" ? "tomorrow" : "date",
+        date: key === "later" ? today : key === "tomorrow" ? tomorrow : validForecastDate(key),
+        grammar,
+        vocabulary,
+        total: grammar + vocabulary
+      };
+    }),
+    forecast_is_projection: true
+  };
+}
+
+export async function listStudyDecks(
+  source: StudySource,
+  input: ListStudyDecksInput
+): Promise<ListStudyDecksOutput> {
+  const operationSignal = AbortSignal.timeout(30_000);
+  await source.checkConnection(operationSignal);
+  const queue = parse(
+    StudyDeckQueueSchema,
+    await source.getFrontendJson(STUDY_DECKS_ROUTE, operationSignal),
+    "study-deck configuration"
+  );
+  const metadataById = new Map(queue.included.map(deck => [deck.id, deck.attributes]));
+  const matching = queue.data.filter(deck => !input.active_only || deck.attributes.actively_studying);
+  const decks = matching.slice(0, input.limit).map(userDeck => {
+    const deckId = String(userDeck.attributes.deck_id);
+    const metadata = metadataById.get(deckId);
+    if (!metadata) {
+      throw new BunproError(
+        "BUNPRO_CONTRACT_CHANGED",
+        "Bunpro returned study-deck configuration without matching deck metadata."
+      );
+    }
+    return {
+      deck_id: deckId,
+      title: metadata.title,
+      slug: metadata.slug,
+      deck_type: metadata.deck_type,
+      actively_studying: userDeck.attributes.actively_studying,
+      batch_size: userDeck.attributes.batch_size,
+      daily_goal: userDeck.attributes.daily_goal,
+      daily_goal_progress: {
+        grammar: userDeck.attributes.daily_goal_count_grammar,
+        vocabulary: userDeck.attributes.daily_goal_count_vocab
+      },
+      completed: {
+        grammar: userDeck.attributes.complete_grammar_count,
+        vocabulary: userDeck.attributes.complete_vocab_count
+      },
+      content: {
+        grammar: metadata.grammar_count,
+        vocabulary: metadata.vocab_count
+      }
+    };
+  });
+  return {
+    active_only: input.active_only,
+    count: decks.length,
+    total_matching: matching.length,
+    has_more: matching.length > decks.length,
+    decks
+  };
+}
+
+export async function getRecentActivity(
+  source: StudySource,
+  input: RecentActivityInput
+): Promise<RecentActivityOutput> {
+  const operationSignal = AbortSignal.timeout(30_000);
+  const connection = await source.checkConnection(operationSignal);
+  const isRollingWindow = input.view === "last_24_hours";
+  const payload = await source.getFrontendJson(
+    isRollingWindow ? LAST_24_HOURS_ROUTE : LATEST_ATTEMPTS_ROUTE,
+    operationSignal
+  );
+  let attempts: z.infer<typeof AttemptSchema>[];
+  let sessions: z.infer<typeof ReviewSessionSchema>[] | null;
+  if (isRollingWindow) {
+    const parsed = parse(Last24HoursSchema, payload, "last-24-hours activity");
+    attempts = parsed.history_objects;
+    sessions = parsed.review_sessions.data;
+  } else {
+    attempts = parse(LatestAttemptsSchema, payload, "latest review attempts");
+    sessions = null;
+  }
+  const normalizedAttempts = attempts.slice(0, input.limit).map(attempt => ({
+    attempt_id: String(attempt.id),
+    time: attempt.time,
+    correct: attempt.status,
+    content_type: attempt.reviewable.data.type,
+    content_id: String(attempt.reviewable.data.id),
+    label: attempt.reviewable.data.attributes.title ??
+      attempt.reviewable.data.attributes.slug ??
+      null
+  }));
+  return {
+    source_timezone: connection.source_timezone,
+    view: input.view,
+    count: normalizedAttempts.length,
+    total_available: attempts.length,
+    has_more: attempts.length > normalizedAttempts.length,
+    completeness: isRollingWindow
+      ? "upstream_rolling_window_not_guaranteed_complete"
+      : "latest_source_records_not_guaranteed_complete",
+    attempts: normalizedAttempts,
+    sessions: sessions === null ? null : {
+      count: sessions.length,
+      xp_delta: sessions.reduce(
+        (total, session) => total + session.attributes.ending_xp - session.attributes.starting_xp,
+        0
+      ),
+      buncoin_delta: sessions.reduce(
+        (total, session) => total + session.attributes.ending_buncoin - session.attributes.starting_buncoin,
+        0
+      )
+    }
+  };
+}
+
+function parse<T>(schema: z.ZodType<T>, payload: unknown, name: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new BunproError(
+      "BUNPRO_CONTRACT_CHANGED",
+      `Bunpro accepted the Account API Token, but the ${name} response shape changed.`
+    );
+  }
+  return parsed.data;
+}
+
+function validForecastDate(value: string): string {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    Number.isNaN(parsed.valueOf()) ||
+    parsed.toISOString().slice(0, 10) !== value) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Bunpro returned an invalid forecast date.");
+  }
+  return value;
+}
+
+function dateInTimeZone(value: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(value);
+}
+
+function addDays(value: string, days: number): string {
+  const date = new Date(`${value}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}

--- a/src/bunpro/schemas.ts
+++ b/src/bunpro/schemas.ts
@@ -122,3 +122,94 @@ export type StudyDaySummary = z.infer<typeof StudyDaySummaryOutputSchema>;
 export type StudyDayEvidence = z.infer<typeof StudyDayEvidenceSchema>;
 export type StudyRangeInput = z.infer<typeof StudyRangeInputSchema>;
 export type StudyRangeSummary = z.infer<typeof StudyRangeSummaryOutputSchema>;
+
+export const ReviewScheduleOutputSchema = z.object({
+  source_timezone: z.string().min(1),
+  retrieved_at: z.string().datetime(),
+  due_now: z.object({
+    grammar: z.number().int().nonnegative(),
+    vocabulary: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative()
+  }),
+  forecast: z.array(z.object({
+    bucket: z.enum(["later_today", "tomorrow", "date"]),
+    date: IsoDateSchema,
+    grammar: z.number().int().nonnegative(),
+    vocabulary: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative()
+  })).max(14),
+  forecast_is_projection: z.literal(true)
+});
+
+export type ReviewSchedule = z.infer<typeof ReviewScheduleOutputSchema>;
+
+export const ListStudyDecksInputSchema = z.object({
+  active_only: z.boolean().default(true).describe("Return only decks currently marked actively studying."),
+  limit: z.number().int().min(1).max(100).default(50).describe("Maximum number of decks to return.")
+}).strict();
+
+export const StudyDeckSchema = z.object({
+  deck_id: z.string().min(1),
+  title: z.string(),
+  slug: z.string(),
+  deck_type: z.string(),
+  actively_studying: z.boolean(),
+  batch_size: z.number().int().nonnegative(),
+  daily_goal: z.number().int().nonnegative(),
+  daily_goal_progress: z.object({
+    grammar: z.number().int().nonnegative(),
+    vocabulary: z.number().int().nonnegative()
+  }),
+  completed: z.object({
+    grammar: z.number().int().nonnegative(),
+    vocabulary: z.number().int().nonnegative()
+  }),
+  content: z.object({
+    grammar: z.number().int().nonnegative(),
+    vocabulary: z.number().int().nonnegative()
+  })
+});
+
+export const ListStudyDecksOutputSchema = z.object({
+  active_only: z.boolean(),
+  count: z.number().int().nonnegative(),
+  total_matching: z.number().int().nonnegative(),
+  has_more: z.boolean(),
+  decks: z.array(StudyDeckSchema).max(100)
+});
+
+export type ListStudyDecksInput = z.infer<typeof ListStudyDecksInputSchema>;
+export type ListStudyDecksOutput = z.infer<typeof ListStudyDecksOutputSchema>;
+
+export const RecentActivityInputSchema = z.object({
+  view: z.enum(["last_24_hours", "latest_attempts"]).default("last_24_hours"),
+  limit: z.number().int().min(1).max(100).default(20)
+}).strict();
+
+export const RecentActivityOutputSchema = z.object({
+  source_timezone: z.string().min(1),
+  view: z.enum(["last_24_hours", "latest_attempts"]),
+  count: z.number().int().nonnegative(),
+  total_available: z.number().int().nonnegative(),
+  has_more: z.boolean(),
+  completeness: z.enum([
+    "upstream_rolling_window_not_guaranteed_complete",
+    "latest_source_records_not_guaranteed_complete"
+  ]),
+  attempts: z.array(z.object({
+    attempt_id: z.string(),
+    time: z.string().min(1),
+    correct: z.boolean(),
+    content_type: z.string().min(1),
+    content_id: z.string().min(1),
+    label: z.string().nullable()
+  })).max(100),
+  sessions: z.object({
+    count: z.number().int().nonnegative(),
+    xp_delta: z.number().int(),
+    buncoin_delta: z.number().int()
+  }).nullable()
+});
+
+export type RecentActivityInput = z.infer<typeof RecentActivityInputSchema>;
+export type RecentActivityOutput = z.infer<typeof RecentActivityOutputSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,9 +7,15 @@ import {
   StudyDayInputSchema,
   StudyDaySummaryOutputSchema,
   StudyRangeInputSchema,
-  StudyRangeSummaryOutputSchema
+  StudyRangeSummaryOutputSchema,
+  ReviewScheduleOutputSchema,
+  ListStudyDecksInputSchema,
+  ListStudyDecksOutputSchema,
+  RecentActivityInputSchema,
+  RecentActivityOutputSchema
 } from "./bunpro/schemas.js";
 import { getStudyDaySummary, getStudyRangeSummary } from "./bunpro/study.js";
+import { getRecentActivity, getReviewSchedule, listStudyDecks } from "./bunpro/planning.js";
 
 export interface BunproAccountAccess {
   checkConnection(operationSignal?: AbortSignal): Promise<ConnectionStatus>;
@@ -108,6 +114,99 @@ export function createServer(
     async input => {
       try {
         const structuredContent = await getStudyRangeSummary(getClient(), input);
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_review_schedule",
+    {
+      title: "Get Bunpro review schedule",
+      description:
+        "Return current grammar and vocabulary reviews due plus Bunpro's forecast from later today through its current daily horizon. Forecast values are projections, not completed study.",
+      inputSchema: z.object({}).strict(),
+      outputSchema: ReviewScheduleOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async () => {
+      try {
+        const structuredContent = await getReviewSchedule(getClient());
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "list_study_decks",
+    {
+      title: "List Bunpro study decks",
+      description:
+        "List bounded Bunpro study-deck configuration, goals, progress, and content counts. These are study decks, not queued review items.",
+      inputSchema: ListStudyDecksInputSchema,
+      outputSchema: ListStudyDecksOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async input => {
+      try {
+        const structuredContent = await listStudyDecks(getClient(), input);
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_recent_activity",
+    {
+      title: "Get recent Bunpro activity",
+      description:
+        "Return a bounded rolling last-24-hours view or latest-attempts view. The source does not guarantee complete history or pagination.",
+      inputSchema: RecentActivityInputSchema,
+      outputSchema: RecentActivityOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async input => {
+      try {
+        const structuredContent = await getRecentActivity(getClient(), input);
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent

--- a/tests/planning-tools.test.ts
+++ b/tests/planning-tools.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/client";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createHttpMcpHandler } from "../src/http-server.js";
+import type { FetchLike } from "../src/bunpro/client.js";
+
+async function withMcpClient(
+  fetchImplementation: FetchLike,
+  run: (client: Client) => Promise<void>
+): Promise<void> {
+  const handler = createHttpMcpHandler(fetchImplementation);
+  const transport = new StreamableHTTPClientTransport(new URL("https://mcp.example/mcp"), {
+    authProvider: { token: async () => "account-token" },
+    fetch: (input, init) => handler.fetch(new Request(input, init))
+  });
+  const client = new Client({ name: "planning-tools-test", version: "0.1.0" });
+  try {
+    await client.connect(transport);
+    await run(client);
+  } finally {
+    await client.close();
+    await handler.close();
+  }
+}
+
+function fixtureFetch(fixtures: Record<string, unknown>, paths: string[]): FetchLike {
+  return async input => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    paths.push(url.pathname);
+    const fixture = fixtures[url.pathname];
+    return fixture === undefined
+      ? new Response("not found", { status: 404 })
+      : Response.json(fixture);
+  };
+}
+
+const userFixture = {
+  user: { data: { attributes: { time_zone_iana: "Asia/Kolkata" } } }
+};
+
+test("get_review_schedule separates due-now work from the normalized 14-day forecast", async () => {
+  const paths: string[] = [];
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user/due": { total_due_grammar: 5, total_due_vocab: 7 },
+    "/api/frontend/user_stats/forecast_daily": {
+      grammar: { later: 2, tomorrow: 3, "2026-08-14": 4 },
+      vocab: { later: 1, tomorrow: 5, "2026-08-14": 6 }
+    }
+  }, paths);
+
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({ name: "get_review_schedule", arguments: {} });
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.equal(output.source_timezone, "Asia/Kolkata");
+    assert.match(output.retrieved_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.deepEqual(output.due_now, { grammar: 5, vocabulary: 7, total: 12 });
+    assert.deepEqual(output.forecast, [
+      { bucket: "later_today", date: "2026-08-12", grammar: 2, vocabulary: 1, total: 3 },
+      { bucket: "tomorrow", date: "2026-08-13", grammar: 3, vocabulary: 5, total: 8 },
+      { bucket: "date", date: "2026-08-14", grammar: 4, vocabulary: 6, total: 10 }
+    ]);
+    assert.deepEqual(paths, [
+      "/api/frontend/user",
+      "/api/frontend/user/due",
+      "/api/frontend/user_stats/forecast_daily"
+    ]);
+  });
+});
+
+test("list_study_decks returns bounded active study configuration without unrelated deck metadata", async () => {
+  const paths: string[] = [];
+  const queue = {
+    data: [
+      {
+        id: "11",
+        type: "user_deck",
+        attributes: {
+          deck_id: 101,
+          actively_studying: true,
+          batch_size: 3,
+          daily_goal: 5,
+          daily_goal_count_grammar: 2,
+          daily_goal_count_vocab: 1,
+          complete_grammar_count: 20,
+          complete_vocab_count: 10,
+          user_id: 999,
+          default_input_type_grammar: "Cloze"
+        }
+      },
+      {
+        id: "12",
+        type: "user_deck",
+        attributes: {
+          deck_id: 102,
+          actively_studying: false,
+          batch_size: 1,
+          daily_goal: 2,
+          daily_goal_count_grammar: 0,
+          daily_goal_count_vocab: 0,
+          complete_grammar_count: 1,
+          complete_vocab_count: 1
+        }
+      }
+    ],
+    included: [
+      {
+        id: "101",
+        type: "deck",
+        attributes: {
+          title: "N3 Grammar",
+          slug: "n3-grammar",
+          deck_type: "grammar",
+          grammar_count: 200,
+          vocab_count: 0,
+          description: "must not be returned",
+          cover_image_url: "https://private.example/image"
+        }
+      },
+      {
+        id: "102",
+        type: "deck",
+        attributes: {
+          title: "Inactive",
+          slug: "inactive",
+          deck_type: "mixed",
+          grammar_count: 1,
+          vocab_count: 1
+        }
+      }
+    ]
+  };
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user/queue": queue
+  }, paths);
+
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({ name: "list_study_decks", arguments: {} });
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(result.structuredContent, {
+      active_only: true,
+      count: 1,
+      total_matching: 1,
+      has_more: false,
+      decks: [{
+        deck_id: "101",
+        title: "N3 Grammar",
+        slug: "n3-grammar",
+        deck_type: "grammar",
+        actively_studying: true,
+        batch_size: 3,
+        daily_goal: 5,
+        daily_goal_progress: { grammar: 2, vocabulary: 1 },
+        completed: { grammar: 20, vocabulary: 10 },
+        content: { grammar: 200, vocabulary: 0 }
+      }]
+    });
+    assert.doesNotMatch(JSON.stringify(result.structuredContent), /description|cover_image|user_id|Cloze/);
+    assert.deepEqual(paths, ["/api/frontend/user", "/api/frontend/user/queue"]);
+  });
+});
+
+test("get_recent_activity returns a bounded last-24-hours view without embedded lesson content", async () => {
+  const paths: string[] = [];
+  const attempt = (id: number, status: boolean) => ({
+    id,
+    time: `2026-08-12T0${id}:00:00.000Z`,
+    status,
+    type: "grammar",
+    study_question: { answer: "must not be returned" },
+    reviewable: {
+      data: {
+        id: String(100 + id),
+        type: "grammar_point",
+        attributes: {
+          title: `Grammar ${id}`,
+          meaning: "embedded meaning must not be returned",
+          nuance: "embedded nuance must not be returned"
+        }
+      }
+    }
+  });
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/summary/last_24_hours": {
+      history_objects: [attempt(1, true), attempt(2, false)],
+      next_review: 123456,
+      review_sessions: {
+        data: [
+          { id: "1", type: "review_session", attributes: {
+            starting_xp: 100,
+            ending_xp: 110,
+            starting_buncoin: 5,
+            ending_buncoin: 7,
+            starting_level: 1
+          } },
+          { id: "2", type: "review_session", attributes: {
+            starting_xp: 110,
+            ending_xp: 125,
+            starting_buncoin: 7,
+            ending_buncoin: 8,
+            starting_level: 1
+          } }
+        ]
+      }
+    }
+  }, paths);
+
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({
+      name: "get_recent_activity",
+      arguments: { limit: 1 }
+    });
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(result.structuredContent, {
+      source_timezone: "Asia/Kolkata",
+      view: "last_24_hours",
+      count: 1,
+      total_available: 2,
+      has_more: true,
+      completeness: "upstream_rolling_window_not_guaranteed_complete",
+      attempts: [{
+        attempt_id: "1",
+        time: "2026-08-12T01:00:00.000Z",
+        correct: true,
+        content_type: "grammar_point",
+        content_id: "101",
+        label: "Grammar 1"
+      }],
+      sessions: { count: 2, xp_delta: 25, buncoin_delta: 3 }
+    });
+    assert.doesNotMatch(JSON.stringify(result.structuredContent), /next_review|answer|meaning|nuance|starting_level/);
+    assert.deepEqual(paths, ["/api/frontend/user", "/api/frontend/summary/last_24_hours"]);
+  });
+});
+
+test("get_recent_activity latest-attempts view calls only the dedicated source", async () => {
+  const paths: string[] = [];
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user_stats/last_done_reviews": [{
+      id: 9,
+      time: "2026-08-12T09:00:00.000Z",
+      status: false,
+      type: "vocab",
+      study_question: null,
+      reviewable: {
+        data: {
+          id: "209",
+          type: "vocabulary",
+          attributes: { slug: "word-slug", meaning: "not returned" }
+        }
+      }
+    }]
+  }, paths);
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({
+      name: "get_recent_activity",
+      arguments: { view: "latest_attempts", limit: 20 }
+    });
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.equal(output.view, "latest_attempts");
+    assert.equal(output.sessions, null);
+    assert.equal(output.attempts[0].label, "word-slug");
+    assert.deepEqual(paths, ["/api/frontend/user", "/api/frontend/user_stats/last_done_reviews"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add due-now and normalized 14-day review forecast tool
- replace the misleading queue concept with bounded study-deck configuration
- add separate last-24-hours and latest-attempts recent-activity views
- authenticate first and omit unrelated deck, lesson, session, and undefined response fields
- document all three read-only tools

## Verification
- MCP-interface synthetic contract tests for schedule, active-deck defaults, redaction, bounds, rolling activity, and latest-attempt route selection
- existing Study Day tests
- TypeScript typecheck and production build
- secret scan and git diff check