### PR TITLE
Complete the read-only Bunpro tool catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An unofficial, stateless, read-only Model Context Protocol (MCP) server for conn
 
 ## Project status
 
-The direct Account API Token connection and date-bounded study summaries are implemented.
+The direct Account API Token connection and the complete read-only tool catalog are implemented.
 
 Available tools:
 
@@ -20,6 +20,8 @@ Available tools:
 - `get_review_schedule` returns reviews due now and Bunpro's current daily forecast.
 - `list_study_decks` returns bounded active study-deck goals and completion counts.
 - `get_recent_activity` returns a bounded last-24-hours or latest-attempts view.
+- `get_learning_progress` returns normalized account totals, JLPT progress, review totals, and cram aggregates.
+- `get_activity_trend` returns preserved daily evidence plus explicitly derived range totals and averages.
 
 The prioritized tool catalog and explicit non-goals are tracked in [docs/tool-roadmap.md](docs/tool-roadmap.md).
 
@@ -119,9 +121,10 @@ The opt-in live connection test uses your own Account API Token and performs rea
 ```bash
 BUNPRO_API_TOKEN="your token" npm run live:test:auth
 BUNPRO_API_TOKEN="your token" npm run live:test:http
+BUNPRO_API_TOKEN="your token" npm run live:test:tools
 ```
 
-The first command tests stdio. The second tests the HTTP Bearer-token passthrough against the real Bunpro API without opening a network listener. Both print only normalized connection status. Do not attach raw Bunpro responses or secrets to issues.
+The first command tests stdio. The second tests the HTTP Bearer-token passthrough. The third makes one deliberately paced pass through every published tool. All use the real Bunpro API without opening a network listener, and the tool sweep prints only tool names and success states. Do not attach raw Bunpro responses or secrets to issues.
 
 ## Contributing
 

--- a/docs/community-post.md
+++ b/docs/community-post.md
@@ -1,53 +1,73 @@
-# Draft private Bunpro community post
+# Public announcement draft
 
-## Title
+## A read-only Bunpro connection for ChatGPT and other MCP clients
 
-I built a private, read-only Bunpro MCP with Account API Token passthrough
+I’ve built a small, unofficial MCP server that lets ChatGPT, Codex, and other MCP-compatible apps read your Bunpro study data.
 
-## Post
+It is useful for questions such as:
 
-Hey everyone — I've been working on a small, unofficial MCP server for Bunpro.
+- How many reviews are due, and what does the forecast look like?
+- What did I study on a particular day or during a date range?
+- Which study decks are active, and how am I progressing through them?
+- What have I reviewed recently?
+- How is my JLPT progress or study trend changing?
 
-The goal is to let ChatGPT, Codex, or another MCP client read useful Bunpro study information without manually copying it over. The repository is staying private, and I'm sharing this only in the Bunpro community group where the temporary Account API Token workaround was documented.
+The connection is read-only. It cannot answer reviews, start lessons, run crams, change your SRS state, or edit your Bunpro account.
 
-The project is read-only. It does not submit reviews, start lessons, or change anything in your Bunpro account.
+### Connect it to ChatGPT
 
-Source code: https://github.com/yash-278/bunpro-mcp
+First, copy your Account API Token from **Bunpro → Settings → API**. Treat this token like a password.
 
-### Hosted version
+In the ChatGPT desktop app, open **Settings → Plugins → MCPs → Add custom MCP**. Enter these settings:
 
-Add this as a Streamable HTTP MCP:
+- **Name:** Bunpro MCP
+- **Type:** Streamable HTTP
+- **URL:** `https://bunpro.yashkadam.com/mcp`
+- **Bearer token environment variable:** leave blank
+- **Protected header name:** `Authorization`
+- **Protected header value:** `Bearer <your Bunpro Account API Token>`
 
-`https://bunpro-mcp-production.up.railway.app/mcp`
+Replace everything inside `<...>` with the token itself; do not include the angle brackets. For example, the value should begin with `Bearer ` followed immediately by your token.
 
-In the ChatGPT/Codex desktop app:
+Save the connection and ask: **“Use Bunpro to check my connection.”** If it fails, reopen the connection and check the URL, the `Authorization` spelling, the space after `Bearer`, and whether the token is still valid.
 
-1. Store the token from Bunpro Settings → API as a secret environment variable named `BUNPRO_API_TOKEN`.
-2. Go to Settings → Plugins → MCPs → Add custom MCP.
-3. Choose Streamable HTTP and paste the URL above.
-4. Set Bearer token env var to `BUNPRO_API_TOKEN`.
-5. Leave custom headers empty, save, and ask it to check your Bunpro connection.
+Other MCP apps can use the same URL and Authorization header, although their menu and field names may differ.
 
-There is no Auth0 login or Bunpro password form. The MCP host sends your Account API Token with each request, and the server does not save it in a database or create a browser session.
+The protected header is connection configuration, not something you should paste into a chat message. Never put your token in a prompt, screenshot, URL, support post, or tool argument.
 
-The hosted operator and platform can technically inspect request memory, so use the local option if you do not want to trust that boundary.
+### What is available
 
-### Local version
+The MCP currently provides eight read-only tools:
 
-```bash
-git clone https://github.com/yash-278/bunpro-mcp.git
-cd bunpro-mcp
-npm ci
-npm run build
-```
+- connection status;
+- one-day study summaries;
+- date-range summaries of up to 93 days, including both dates you choose;
+- reviews due now and the current forecast;
+- active study decks and their goals;
+- recent activity from the last 24 hours or the latest reviews Bunpro provides;
+- account and JLPT learning progress; and
+- daily activity trends with review, new-content, and accuracy coverage.
 
-Then add `dist/index.js` as an STDIO MCP and provide `BUNPRO_API_TOKEN` through your MCP client's secret environment configuration.
+Some useful prompts to try:
 
-### Current limitations
+- “How many Bunpro reviews are due, and what does the next week look like?”
+- “Summarize my Bunpro activity for yesterday.”
+- “Compare my study activity over the last 14 days.”
+- “Show my progress from N5 through N1.”
+- “Which Bunpro study decks are currently active?”
 
-- This is an early private preview. The connection check works; the date-based study-summary tool is next.
-- It uses Bunpro's experimental, undocumented Frontend API token mechanism, so routes or response shapes may change without warning.
-- Bunpro has added stricter throttling and plans to move to a route whitelist. The MCP stays read-only and low-volume and does not retry aggressively.
-- The server cannot promise that today's available routes will remain available.
+### Privacy and security
 
-If something fails, please share only a sanitized error. Never post your Account API Token, Authorization header, or raw account responses.
+Your MCP app sends your token to the hosted server over HTTPS whenever it asks for Bunpro data. The application uses the token for that request and has no token database, user profile, or saved study history. Its own application logs are designed not to include tokens, request headers, or returned study data.
+
+This is still my hosted service, running through a hosting provider. Anyone with privileged access to that infrastructure could technically inspect data while a request is being handled. Only connect if you are comfortable trusting both me and the hosting provider. “Read-only” describes the actions exposed by this MCP; your token can still reveal private Bunpro account and study information, so continue to treat it like a password.
+
+Removing the connection stops the app from sending your token, but it does not invalidate the token. To revoke an exposed or previously saved token, rotate it from **Bunpro → Settings → API**. Update the saved header only if you want to reconnect with the new token.
+
+### Important limitations
+
+This project is unofficial and is not affiliated with or endorsed by Bunpro. Bunpro does not promise that this connection will keep working. It may become unavailable, be rate-limited, or return incomplete results after future changes. If a date has no available record, the MCP reports that uncertainty instead of claiming you studied zero items.
+
+The hosted server is a free, best-effort community service with no uptime or support guarantee. Access may be limited or suspended if necessary to avoid putting excessive traffic on Bunpro. The MCP remains read-only even when a request fails.
+
+If you run into a problem, reply or contact me privately with the tool name, approximate time, and a sanitized error message. Please never send your token, Authorization header, screenshots containing credentials, or raw account data.

--- a/docs/community-post.md
+++ b/docs/community-post.md
@@ -66,7 +66,7 @@ Removing the connection stops the app from sending your token, but it does not i
 
 ### Important limitations
 
-This project is unofficial and is not affiliated with or endorsed by Bunpro. Bunpro does not promise that this connection will keep working. It may become unavailable, be rate-limited, or return incomplete results after future changes. If a date has no available record, the MCP reports that uncertainty instead of claiming you studied zero items.
+This project is unofficial and is not affiliated with or endorsed by Bunpro. It depends on experimental Bunpro functionality that is not supported as a stable public integration. It may become unavailable, be rate-limited, or return incomplete results after future changes. If a date has no available record, the MCP reports that uncertainty instead of claiming you studied zero items.
 
 The hosted server is a free, best-effort community service with no uptime or support guarantee. Access may be limited or suspended if necessary to avoid putting excessive traffic on Bunpro. The MCP remains read-only even when a request fails.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,36 +1,43 @@
-# Private preview checklist
+# Hosted community release checklist
 
-Keep the repository private and share the connection only inside the approved Bunpro community group.
+The hosted MCP may be announced publicly. The repository and Bunpro-specific request mechanism must remain private.
 
-## Repository
+## Repository boundary
 
-- [x] MIT license present.
-- [x] README documents hosted, local, and self-hosted setup.
-- [x] Privacy, security, contribution, and conduct policies present.
-- [x] Current tree and Git history scanned for committed credentials.
-- [x] Account API Token request contract captured in a confidential research note.
-- [x] Confirm no active documentation instructs users to provide a Bunpro password, Auth0 login, database, or setup link.
-- [x] Run the full verification suite after the direct-token cutover.
+- [x] Repository policy explicitly requires GitHub visibility to remain private.
+- [x] Public documentation excludes private routes, authentication translation, opt-in parameters, schemas, reverse-engineering notes, and source code.
+- [x] README documents the implemented read-only catalog and maintainer setup.
+- [x] Privacy, security, contribution, and conduct policies are present.
+- [ ] Re-scan the current tree and Git history for credentials immediately before merge.
+- [ ] Confirm `yash-278/bunpro-mcp` reports `PRIVATE` before and after the release merge.
 
 ## Hosted service
 
-- [ ] Remove obsolete Auth0, PostgreSQL, encryption-key, setup-token, username, and password variables from Railway.
-- [ ] Redeploy the direct-token build.
-- [ ] Confirm `GET /healthz` returns HTTP 200.
-- [ ] Confirm a missing Bearer token receives HTTP 401 without leaking request data.
-- [ ] Confirm one valid caller token reaches `get_connection_status` and is not persisted.
-- [ ] Confirm one invalid token produces a sanitized Bunpro authentication error.
+- [ ] Railway deploys automatically from the private repository's `main` branch.
+- [ ] Set `PUBLIC_BASE_URL=https://bunpro.yashkadam.com`.
+- [ ] Remove obsolete Auth0, database, encryption-key, setup-token, username, password, and deployment-wide Bunpro token variables.
+- [ ] Confirm `GET /healthz` returns HTTP 200 on the canonical domain.
+- [ ] Confirm the generated Railway domain is not an alternate public entry point after the canonical domain works.
+- [ ] Confirm a missing or malformed Bearer token receives HTTP 401 without leaking request data.
+- [ ] Run one low-volume live smoke pass across every published tool with a valid caller token.
+- [ ] Confirm one invalid token produces a sanitized authentication error.
+- [ ] Review edge rate limits and abuse controls without logging Authorization headers or response bodies.
 
-## Atlas acceptance
+## Product behavior
 
-- [ ] Implement the date-bounded Study Day Summary using only whitelisted read routes.
-- [ ] Compare at least one known Study Day with Bunpro.
-- [ ] Simulate authentication, throttling, or route-drift failure and verify Atlas does not advance its Bunpro Watermark.
+- [x] All published tools are read-only, stateless, bounded, and annotated as non-destructive.
+- [x] Authentication, throttling, route removal, and schema drift fail closed.
+- [x] Sparse historical absence is not silently represented as zero study.
+- [x] The server stores no caller credential, session, cookie, account profile, watermark, or study history.
+- [ ] Complete the final automated verification suite and private pull-request review.
 
-## Sharing boundary
+## Public announcement
 
-- [ ] Keep the GitHub repository private.
-- [ ] Recheck every link in the README and private community draft.
-- [ ] Share [the draft](community-post.md) only in the approved private Bunpro community group.
+- [x] The draft explains setup using only the hosted URL and standard protected Bearer header.
+- [x] The draft explains all eight capabilities in user-facing language.
+- [x] The draft discloses the unofficial/experimental status, partial failures, throttling, hosted-operator trust boundary, best-effort availability, and token rotation.
+- [x] The draft does not link to or describe how to reproduce the private implementation.
+- [x] Reader-test [the public announcement draft](community-post.md) for clarity and accidental disclosure.
+- [ ] Publish only after every hosted-service gate above is complete.
 
-Do not publish the temporary token mechanism in a public forum.
+Atlas integration is intentionally out of scope for this release. Do not edit the Atlas vault or infer an Atlas watermark from MCP output during release work.

--- a/docs/tool-roadmap.md
+++ b/docs/tool-roadmap.md
@@ -1,6 +1,6 @@
 # Bunpro MCP tool roadmap
 
-Status: design inventory for the private, read-only MCP
+Status: implemented catalog for the private, read-only MCP
 
 This roadmap translates the confirmed Bunpro Frontend API surfaces into agent-facing workflows. It is intentionally not a one-tool-per-endpoint wrapper. Each tool should answer a recognizable user question, return structured content, disclose source coverage, and stay within a conservative Bunpro request budget.
 
@@ -63,7 +63,7 @@ This is a separate tool because it makes catch-up cheap and prevents an agent fr
 
 ## Priority 1: current review planning
 
-These tools are useful to people directly, but they are not required for the first Atlas ingestion milestone. Their routes were successful in the earlier authenticated Frontend API inventory; Account API Token access and current response schemas must be revalidated with one low-volume probe per route before implementation.
+These tools are useful directly to Bunpro learners and are independent of any Atlas integration.
 
 ### `get_review_schedule` — implemented
 
@@ -94,22 +94,22 @@ Answers: "What did I review recently?" or "What happened in the last 24 hours?"
 
 ## Priority 2: progress and trends
 
-### `get_learning_progress`
+### `get_learning_progress` — implemented
 
 Answers: "How far along am I in Bunpro?"
 
-- Candidate sources: `/api/frontend/user_stats/base_stats`, `/api/frontend/user_stats/jlpt_progress_mixed`, `/api/frontend/user_stats/total_review_stats`, `/api/frontend/user_stats/total_cram_stats`
-- Input: optional view selection only if it reduces output materially
-- Output: normalized JLPT/SRS progress, supported account aggregates, review totals, cram totals, and coverage
+- Sources: `/api/frontend/user_stats/base_stats`, `/api/frontend/user_stats/jlpt_progress_mixed`, `/api/frontend/user_stats/total_review_stats`, `/api/frontend/user_stats/total_cram_stats`
+- Input: none
+- Output: normalized account facts, JLPT N5-N1 SRS-stage progress, JLPT review totals, and cram aggregates
 - Important boundary: avoid returning cosmetic, subscription, or unrelated profile fields from `/user`
 
-### `get_activity_trend`
+### `get_activity_trend` — implemented
 
 Answers: "How has my study consistency and accuracy changed over the last 30 days?"
 
-- Candidate sources: `/api/frontend/user_stats/activity_daily`, `/api/frontend/user_stats/review_heatmap`, `/api/frontend/user_stats/new_content_heatmap`, `/api/frontend/user_stats/accuracy_over_time`
+- Sources: `/api/frontend/user_stats/review_heatmap`, `/api/frontend/user_stats/new_content_heatmap`, `/api/frontend/user_stats/accuracy_over_time`
 - Input: inclusive bounded range, initially no more than 93 days
-- Output: daily series, active-day count, supported aggregates, and independent coverage windows for activity and accuracy
+- Output: preserved daily review, new-content, and accuracy evidence; source-record-day counts; supported totals and averages; and independent coverage windows
 - Important boundary: this tool may derive trends but must preserve the underlying daily values and label every derived measure
 
 ## Deliberately excluded tools
@@ -123,14 +123,14 @@ Do not create these under the current project contract:
 - tools claiming study duration, exact correct/incorrect daily totals, or complete historical item lists without a proven source;
 - separate tools for badges, cosmetics, profile decoration, subscription state, or unrelated account metadata.
 
-## Implementation order
+## Implementation history
 
-1. Resolve the Study Day source-to-summary vocabulary and sparse-key behavior.
-2. Implement the shared daily-series parser and `get_study_day_summary` with schema, mapping, and failure tests.
-3. Add `get_study_range_summary` using the same fetched payloads and mapper.
-4. Prototype the Atlas ingestion contract and watermark behavior against the two tools.
-5. Implement the verified review schedule, study-deck, and recent-activity contracts.
-6. Revalidate and implement Priority 2 progress/trend tools only after the Atlas path is functional.
+1. Resolved the Study Day source-to-summary vocabulary and sparse-key behavior.
+2. Implemented the shared daily-series parser and Study Day/range summaries.
+3. Implemented review schedule, study-deck, and recent-activity contracts.
+4. Revalidated and implemented learning-progress and activity-trend tools.
+
+Atlas integration remains a separate consumer project. The MCP does not own Atlas files or watermarks.
 
 ## Minimum test matrix for every new tool
 

--- a/evaluations/README.md
+++ b/evaluations/README.md
@@ -1,0 +1,11 @@
+# Deterministic MCP evaluations
+
+The evaluation account is synthetic. It exists so tool-selection and multi-tool reasoning can be tested without committing a real Bunpro user's study history or relying on values that change over time.
+
+Run the standard MCP evaluation harness against `bunpro-tools.xml` with this stdio command:
+
+```bash
+node --import tsx scripts/evaluation-fixture-server.ts
+```
+
+The fixture server uses the production tool registrations and mappers with a fixed, read-only data source. It does not require a Bunpro token or make network requests.

--- a/evaluations/bunpro-tools.xml
+++ b/evaluations/bunpro-tools.xml
@@ -1,0 +1,42 @@
+<evaluation>
+  <qa_pair>
+    <question>For the synthetic account, inspect 2026-07-01 through 2026-07-07 with both the range and trend tools. On the day with the highest review total, what was the reported accuracy percentage? Answer with only the number.</question>
+    <answer>75</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use the range summary and verify individual days as needed for 2026-07-01 through 2026-07-07. How many days have both a review source record and a new-content source record? Answer with only the number.</question>
+    <answer>3</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Compare the review and new-content aggregates from both the range summary and activity trend for 2026-07-01 through 2026-07-07. What is total reviews minus total new content? Answer with only the number.</question>
+    <answer>45</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Find the active study deck with the largest combined grammar and vocabulary content count, then compare its daily goal with the account's current streak from learning progress. By how much does the goal exceed the streak? Answer with only the number.</question>
+    <answer>18</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use the review schedule and active study-deck list. If reviews currently due were distributed evenly across the active decks, how many reviews would each deck receive? Answer with only the number.</question>
+    <answer>10</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Compute the correct percentage across all records in the latest-attempts view, then compare it with the average historical accuracy from the activity trend for 2026-07-01 through 2026-07-07. What is the absolute difference in percentage points? Answer with only the number.</question>
+    <answer>11</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Use the last-24-hours activity view and the current review schedule. By how much does the total XP gained across the returned sessions exceed the total reviews due now? Answer with only the number.</question>
+    <answer>30</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Compare N5 combined content progress with the largest active study deck's combined grammar and vocabulary content count. What percentage is the N5 total of that deck total? Answer with only the whole number.</question>
+    <answer>20</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>For 2026-07-01 through 2026-07-07, add the number of days having a review source record to the number of incorrect records in the complete latest-attempts result. Answer with only the number.</question>
+    <answer>6</answer>
+  </qa_pair>
+  <qa_pair>
+    <question>Check the connection timezone, then request the 2026-07-01 through 2026-07-07 range with Asia/Kolkata as the expected timezone. Do both the connection and range result confirm the same boundary? Answer True or False.</question>
+    <answer>True</answer>
+  </qa_pair>
+</evaluation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bunpro-mcp-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "start": "node dist/index.js",
     "start:http": "TRANSPORT=http node dist/index.js",
     "live:test:auth": "npm run build && node --import tsx scripts/live-mcp-auth-smoke.ts",
-    "live:test:http": "npm run build && node --import tsx scripts/live-http-passthrough-smoke.ts"
+    "live:test:http": "npm run build && node --import tsx scripts/live-http-passthrough-smoke.ts",
+    "live:test:tools": "npm run build && node --import tsx scripts/live-all-tools-smoke.ts"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Unofficial stateless, read-only Bunpro MCP with direct Account API Token passthrough",
   "type": "module",
   "private": true,

--- a/scripts/evaluation-fixture-server.ts
+++ b/scripts/evaluation-fixture-server.ts
@@ -190,7 +190,6 @@ const fixtures: Record<string, unknown> = {
       grammar_studied: 400,
       vocab_studied: 250,
       streak: 7,
-      total_badges: 12,
       weekly_streak: [
         { day: "Mon", val: true },
         { day: "Tue", val: true },

--- a/scripts/evaluation-fixture-server.ts
+++ b/scripts/evaluation-fixture-server.ts
@@ -1,0 +1,256 @@
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { createServer, type BunproAccountAccess } from "../src/server.js";
+
+const levels = Object.fromEntries(
+  [1, 2, 3, 4, 5].map(level => [String(level), {
+    beginner: level,
+    seasoned: level + 1,
+    adept: level + 2,
+    expert: level + 3,
+    master: level + 4,
+    total_count: level * 8
+  }])
+);
+const vocabularyLevels = Object.fromEntries(
+  [1, 2, 3, 4, 5].map(level => [String(level), {
+    beginner: level + 1,
+    seasoned: level + 2,
+    adept: level + 3,
+    expert: level + 4,
+    master: level + 5,
+    total_count: level * 12
+  }])
+);
+const reviewLevels = Object.fromEntries(
+  [1, 2, 3, 4, 5].map(level => [String(level), {
+    accuracy: 70 + level * 5,
+    correct: level * 12,
+    incorrect: level * 3,
+    total: level * 15,
+    global: 999
+  }])
+);
+const fixtures: Record<string, unknown> = {
+  "/api/frontend/user_stats/review_heatmap": {
+    grammar: {
+      "2026-07-01": 7,
+      "2026-07-02": 4,
+      "2026-07-04": 12,
+      "2026-07-05": 3,
+      "2026-07-07": 8
+    },
+    vocab: {
+      "2026-07-01": 3,
+      "2026-07-02": 6,
+      "2026-07-04": 8,
+      "2026-07-05": 2,
+      "2026-07-07": 7
+    },
+    mixed: {
+      "2026-07-01": 10,
+      "2026-07-02": 10,
+      "2026-07-04": 20,
+      "2026-07-05": 5,
+      "2026-07-07": 15
+    }
+  },
+  "/api/frontend/user_stats/new_content_heatmap": {
+    grammar: {
+      "2026-07-02": 1,
+      "2026-07-03": 2,
+      "2026-07-05": 2,
+      "2026-07-07": 1
+    },
+    vocab: {
+      "2026-07-02": 1,
+      "2026-07-03": 1,
+      "2026-07-05": 3,
+      "2026-07-07": 4
+    },
+    mixed: {
+      "2026-07-02": 2,
+      "2026-07-03": 3,
+      "2026-07-05": 5,
+      "2026-07-07": 5
+    }
+  },
+  "/api/frontend/user_stats/accuracy_over_time": {
+    "2026-07-01": 80,
+    "2026-07-02": 90,
+    "2026-07-04": 75,
+    "2026-07-05": 100,
+    "2026-07-07": 85
+  },
+  "/api/frontend/user/due": {
+    total_due_grammar: 12,
+    total_due_vocab: 8
+  },
+  "/api/frontend/user_stats/forecast_daily": {
+    grammar: { later: 2, tomorrow: 4, "2026-08-14": 6, "2026-08-15": 8 },
+    vocab: { later: 3, tomorrow: 6, "2026-08-14": 4, "2026-08-15": 2 }
+  },
+  "/api/frontend/user/queue": {
+    data: [
+      {
+        id: "user-deck-101",
+        attributes: {
+          deck_id: 101,
+          actively_studying: true,
+          batch_size: 5,
+          daily_goal: 10,
+          daily_goal_count_grammar: 4,
+          daily_goal_count_vocab: 1,
+          complete_grammar_count: 60,
+          complete_vocab_count: 20
+        }
+      },
+      {
+        id: "user-deck-202",
+        attributes: {
+          deck_id: 202,
+          actively_studying: true,
+          batch_size: 10,
+          daily_goal: 25,
+          daily_goal_count_grammar: 9,
+          daily_goal_count_vocab: 6,
+          complete_grammar_count: 180,
+          complete_vocab_count: 75
+        }
+      },
+      {
+        id: "user-deck-303",
+        attributes: {
+          deck_id: 303,
+          actively_studying: false,
+          batch_size: 20,
+          daily_goal: 40,
+          daily_goal_count_grammar: 0,
+          daily_goal_count_vocab: 0,
+          complete_grammar_count: 500,
+          complete_vocab_count: 500
+        }
+      }
+    ],
+    included: [
+      {
+        id: "101",
+        attributes: {
+          title: "Starter Grammar",
+          slug: "starter-grammar",
+          deck_type: "grammar",
+          grammar_count: 100,
+          vocab_count: 50
+        }
+      },
+      {
+        id: "202",
+        attributes: {
+          title: "Tobira Intermediate",
+          slug: "tobira-intermediate",
+          deck_type: "mixed",
+          grammar_count: 300,
+          vocab_count: 200
+        }
+      },
+      {
+        id: "303",
+        attributes: {
+          title: "Archived Advanced",
+          slug: "archived-advanced",
+          deck_type: "mixed",
+          grammar_count: 600,
+          vocab_count: 400
+        }
+      }
+    ]
+  },
+  "/api/frontend/user_stats/last_done_reviews": [
+    attempt(1, true, "Grammar A"),
+    attempt(2, false, "Vocabulary B"),
+    attempt(3, true, "Grammar C"),
+    attempt(4, true, "Vocabulary D")
+  ],
+  "/api/frontend/summary/last_24_hours": {
+    history_objects: [
+      attempt(1, true, "Grammar A"),
+      attempt(2, false, "Vocabulary B"),
+      attempt(3, true, "Grammar C")
+    ],
+    next_review: 123,
+    review_sessions: {
+      data: [
+        { attributes: { starting_xp: 100, ending_xp: 130, starting_buncoin: 10, ending_buncoin: 15 } },
+        { attributes: { starting_xp: 200, ending_xp: 220, starting_buncoin: 20, ending_buncoin: 22 } }
+      ]
+    }
+  },
+  "/api/frontend/user_stats/base_stats": {
+    facts: {
+      days_studied: 120,
+      grammar_studied: 400,
+      vocab_studied: 250,
+      streak: 7,
+      total_badges: 12,
+      weekly_streak: [
+        { day: "Mon", val: true },
+        { day: "Tue", val: true },
+        { day: "Wed", val: false }
+      ]
+    }
+  },
+  "/api/frontend/user_stats/jlpt_progress_mixed": {
+    grammar: levels,
+    vocab: vocabularyLevels
+  },
+  "/api/frontend/user_stats/total_review_stats": {
+    grammar: reviewLevels,
+    vocab: reviewLevels,
+    mixed: reviewLevels
+  },
+  "/api/frontend/user_stats/total_cram_stats": {
+    items: { accuracy: 80, correct: 80, incorrect: 20, total: 100 },
+    sessions: {
+      average_time: "00:10:00",
+      reviews_per_session: 25,
+      session_count: 4,
+      total_time: "00:40:00"
+    }
+  }
+};
+
+const source: BunproAccountAccess = {
+  async checkConnection() {
+    return {
+      connected: true,
+      authentication_method: "account_api_token",
+      token_source: "environment",
+      token_persisted_by_server: false,
+      api_authenticated: true,
+      source_timezone: "Asia/Kolkata",
+      stateless: true
+    };
+  },
+  async getFrontendJson(path) {
+    if (!Object.hasOwn(fixtures, path)) {
+      throw new Error(`Missing evaluation fixture for ${path}`);
+    }
+    return fixtures[path];
+  }
+};
+
+void serveStdio(() => createServer(() => source));
+
+function attempt(id: number, status: boolean, title: string) {
+  return {
+    id,
+    time: `2026-07-07T0${id}:00:00+05:30`,
+    status,
+    reviewable: {
+      data: {
+        id: id * 10,
+        type: id % 2 === 0 ? "vocabulary" : "grammar",
+        attributes: { title }
+      }
+    }
+  };
+}

--- a/scripts/live-all-tools-smoke.ts
+++ b/scripts/live-all-tools-smoke.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createHttpMcpHandler } from "../src/http-server.js";
+
+const apiToken = process.env.BUNPRO_API_TOKEN;
+assert.ok(apiToken, "BUNPRO_API_TOKEN must be configured for the live tool smoke test.");
+
+const handler = createHttpMcpHandler();
+const transport = new StreamableHTTPClientTransport(new URL("https://local-smoke.invalid/mcp"), {
+  authProvider: { token: async () => apiToken },
+  fetch: (input, init) => handler.fetch(new Request(input, init))
+});
+const client = new Client({ name: "bunpro-mcp-all-tools-smoke", version: "0.1.0" });
+
+try {
+  await client.connect(transport);
+  const connection = await call("get_connection_status", {});
+  const timezone = requiredString(connection, "source_timezone");
+  const today = calendarDate(new Date(), timezone);
+  const yesterday = addDays(today, -1);
+  const weekStart = addDays(yesterday, -6);
+
+  await pause();
+  await call("get_study_day_summary", { date: yesterday, expected_timezone: timezone });
+  await pause();
+  await call("get_study_range_summary", {
+    start_date: weekStart,
+    end_date: yesterday,
+    expected_timezone: timezone
+  });
+  await pause();
+  await call("get_review_schedule", {});
+  await pause();
+  await call("list_study_decks", { active_only: true, limit: 1 });
+  await pause();
+  await call("get_recent_activity", { view: "last_24_hours", limit: 1 });
+  await pause();
+  await call("get_learning_progress", {});
+  await pause();
+  await call("get_activity_trend", {
+    start_date: weekStart,
+    end_date: yesterday,
+    expected_timezone: timezone
+  });
+} finally {
+  await client.close();
+  await handler.close();
+}
+
+async function call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const result = await client.callTool({ name, arguments: args });
+  assert.equal(result.isError, undefined, `${name} returned an MCP error.`);
+  assert.ok(result.structuredContent, `${name} did not return structured content.`);
+  process.stdout.write(`${name}: ok\n`);
+  return result.structuredContent as Record<string, unknown>;
+}
+
+function requiredString(value: Record<string, unknown>, key: string): string {
+  const candidate = value[key];
+  if (typeof candidate !== "string") {
+    throw new Error(`${key} must be a string.`);
+  }
+  return candidate;
+}
+
+function calendarDate(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(date);
+}
+
+function addDays(date: string, amount: number): string {
+  const value = new Date(`${date}T00:00:00Z`);
+  value.setUTCDate(value.getUTCDate() + amount);
+  return value.toISOString().slice(0, 10);
+}
+
+async function pause(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 750));
+}

--- a/src/bunpro/progress.ts
+++ b/src/bunpro/progress.ts
@@ -1,0 +1,224 @@
+import * as z from "zod/v4";
+import { BunproError } from "./errors.js";
+import type { ActivityTrend, LearningProgress, StudyRangeInput } from "./schemas.js";
+import { getStudyRangeSummary, type StudySource } from "./study.js";
+
+const BASE_STATS_ROUTE = "/api/frontend/user_stats/base_stats";
+const JLPT_PROGRESS_ROUTE = "/api/frontend/user_stats/jlpt_progress_mixed";
+const TOTAL_REVIEW_STATS_ROUTE = "/api/frontend/user_stats/total_review_stats";
+const TOTAL_CRAM_STATS_ROUTE = "/api/frontend/user_stats/total_cram_stats";
+const JLPT_KEYS = ["5", "4", "3", "2", "1"] as const;
+
+const StageCountsSchema = z.object({
+  beginner: z.number().int().nonnegative(),
+  seasoned: z.number().int().nonnegative(),
+  adept: z.number().int().nonnegative(),
+  expert: z.number().int().nonnegative(),
+  master: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative()
+}).loose();
+const ReviewAggregateSourceSchema = z.object({
+  accuracy: z.number(),
+  correct: z.number().int().nonnegative(),
+  incorrect: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative()
+}).loose();
+const BaseStatsSchema = z.object({
+  facts: z.object({
+    days_studied: z.number().int().nonnegative(),
+    grammar_studied: z.number().int().nonnegative(),
+    vocab_studied: z.number().int().nonnegative(),
+    streak: z.number().int().nonnegative(),
+    total_badges: z.number().int().nonnegative(),
+    weekly_streak: z.array(z.object({ day: z.string(), val: z.boolean() }).loose())
+  }).loose()
+}).loose();
+const JlptProgressSchema = z.object({
+  grammar: z.record(z.string(), StageCountsSchema),
+  vocab: z.record(z.string(), StageCountsSchema)
+});
+const TotalReviewStatsSchema = z.object({
+  grammar: z.record(z.string(), ReviewAggregateSourceSchema),
+  vocab: z.record(z.string(), ReviewAggregateSourceSchema),
+  mixed: z.record(z.string(), ReviewAggregateSourceSchema)
+});
+const TotalCramStatsSchema = z.object({
+  items: ReviewAggregateSourceSchema,
+  sessions: z.object({
+    average_time: z.string(),
+    reviews_per_session: z.number().int().nonnegative(),
+    session_count: z.number().int().nonnegative(),
+    total_time: z.string()
+  }).loose()
+});
+
+export async function getLearningProgress(
+  source: StudySource,
+  now: Date = new Date()
+): Promise<LearningProgress> {
+  const operationSignal = AbortSignal.timeout(30_000);
+  await source.checkConnection(operationSignal);
+  const base = parse(
+    BaseStatsSchema,
+    await source.getFrontendJson(BASE_STATS_ROUTE, operationSignal),
+    "base statistics"
+  );
+  const jlpt = parse(
+    JlptProgressSchema,
+    await source.getFrontendJson(JLPT_PROGRESS_ROUTE, operationSignal),
+    "JLPT progress"
+  );
+  const reviews = parse(
+    TotalReviewStatsSchema,
+    await source.getFrontendJson(TOTAL_REVIEW_STATS_ROUTE, operationSignal),
+    "total review statistics"
+  );
+  const cram = parse(
+    TotalCramStatsSchema,
+    await source.getFrontendJson(TOTAL_CRAM_STATS_ROUTE, operationSignal),
+    "total cram statistics"
+  );
+  assertJlptKeys(jlpt.grammar, jlpt.vocab, reviews.grammar, reviews.vocab, reviews.mixed);
+
+  return {
+    retrieved_at: now.toISOString(),
+    base: {
+      days_studied: base.facts.days_studied,
+      grammar_studied: base.facts.grammar_studied,
+      vocabulary_studied: base.facts.vocab_studied,
+      current_streak: base.facts.streak,
+      total_badges: base.facts.total_badges,
+      weekly_streak: base.facts.weekly_streak.map(day => ({ day: day.day, studied: day.val }))
+    },
+    jlpt_progress: JLPT_KEYS.map(key => {
+      const grammar = requiredLevel(jlpt.grammar, key);
+      const vocabulary = requiredLevel(jlpt.vocab, key);
+      return {
+        jlpt_level: `N${key}` as "N5" | "N4" | "N3" | "N2" | "N1",
+        grammar: stageCounts(grammar),
+        vocabulary: stageCounts(vocabulary),
+        combined: {
+          ...addStageCounts(grammar, vocabulary),
+          derived: true as const
+        }
+      };
+    }),
+    review_totals: JLPT_KEYS.map(key => ({
+      jlpt_level: `N${key}` as "N5" | "N4" | "N3" | "N2" | "N1",
+      grammar: reviewAggregate(requiredLevel(reviews.grammar, key)),
+      vocabulary: reviewAggregate(requiredLevel(reviews.vocab, key)),
+      mixed: {
+        ...reviewAggregate(requiredLevel(reviews.mixed, key)),
+        source_supplied: true as const
+      }
+    })),
+    cram: {
+      items: reviewAggregate(cram.items),
+      sessions: {
+        average_time: cram.sessions.average_time,
+        reviews_per_session: cram.sessions.reviews_per_session,
+        session_count: cram.sessions.session_count,
+        total_time: cram.sessions.total_time
+      }
+    }
+  };
+}
+
+export async function getActivityTrend(
+  source: StudySource,
+  input: StudyRangeInput
+): Promise<ActivityTrend> {
+  const range = await getStudyRangeSummary(source, input);
+  const reviewCount = range.aggregates.reviews.source_record_days;
+  const newContentCount = range.aggregates.new_content.source_record_days;
+  return {
+    requested_start_date: range.requested_start_date,
+    requested_end_date: range.requested_end_date,
+    source_timezone: range.source_timezone,
+    expected_timezone: range.expected_timezone,
+    timezone_matches: range.timezone_matches,
+    overall_query_status: range.overall_query_status,
+    days: range.days,
+    metrics: {
+      reviews: {
+        source_record_days: reviewCount,
+        total: range.aggregates.reviews.source_total,
+        average_per_source_record_day: reviewCount === 0
+          ? null
+          : range.aggregates.reviews.source_total / reviewCount
+      },
+      new_content: {
+        source_record_days: newContentCount,
+        total: range.aggregates.new_content.source_total,
+        average_per_source_record_day: newContentCount === 0
+          ? null
+          : range.aggregates.new_content.source_total / newContentCount
+      },
+      accuracy: {
+        source_record_days: range.aggregates.accuracy.source_record_days,
+        average_percent: range.aggregates.accuracy.average_percent
+      }
+    },
+    derived_measures_labeled: true,
+    source_coverage: range.source_coverage
+  };
+}
+
+function parse<T>(schema: z.ZodType<T>, payload: unknown, name: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new BunproError(
+      "BUNPRO_CONTRACT_CHANGED",
+      `Bunpro accepted the Account API Token, but the ${name} response shape changed.`
+    );
+  }
+  return parsed.data;
+}
+
+function assertJlptKeys(...groups: Array<Record<string, unknown>>): void {
+  if (groups.some(group => Object.keys(group).sort().join(",") !== "1,2,3,4,5")) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Bunpro returned unexpected JLPT level groups.");
+  }
+}
+
+function requiredLevel<T>(group: Record<string, T>, key: string): T {
+  const value = group[key];
+  if (value === undefined) {
+    throw new BunproError("BUNPRO_CONTRACT_CHANGED", "Bunpro omitted a required JLPT level.");
+  }
+  return value;
+}
+
+function stageCounts(value: z.infer<typeof StageCountsSchema>) {
+  return {
+    beginner: value.beginner,
+    seasoned: value.seasoned,
+    adept: value.adept,
+    expert: value.expert,
+    master: value.master,
+    total_count: value.total_count
+  };
+}
+
+function addStageCounts(
+  left: z.infer<typeof StageCountsSchema>,
+  right: z.infer<typeof StageCountsSchema>
+) {
+  return {
+    beginner: left.beginner + right.beginner,
+    seasoned: left.seasoned + right.seasoned,
+    adept: left.adept + right.adept,
+    expert: left.expert + right.expert,
+    master: left.master + right.master,
+    total_count: left.total_count + right.total_count
+  };
+}
+
+function reviewAggregate(value: z.infer<typeof ReviewAggregateSourceSchema>) {
+  return {
+    accuracy: value.accuracy,
+    correct: value.correct,
+    incorrect: value.incorrect,
+    total: value.total
+  };
+}

--- a/src/bunpro/progress.ts
+++ b/src/bunpro/progress.ts
@@ -18,7 +18,7 @@ const StageCountsSchema = z.object({
   total_count: z.number().int().nonnegative()
 }).loose();
 const ReviewAggregateSourceSchema = z.object({
-  accuracy: z.number(),
+  accuracy: z.number().min(0).max(100),
   correct: z.number().int().nonnegative(),
   incorrect: z.number().int().nonnegative(),
   total: z.number().int().nonnegative()
@@ -29,8 +29,7 @@ const BaseStatsSchema = z.object({
     grammar_studied: z.number().int().nonnegative(),
     vocab_studied: z.number().int().nonnegative(),
     streak: z.number().int().nonnegative(),
-    total_badges: z.number().int().nonnegative(),
-    weekly_streak: z.array(z.object({ day: z.string(), val: z.boolean() }).loose())
+    weekly_streak: z.array(z.object({ day: z.string(), val: z.boolean() }).loose()).max(7)
   }).loose()
 }).loose();
 const JlptProgressSchema = z.object({
@@ -87,7 +86,6 @@ export async function getLearningProgress(
       grammar_studied: base.facts.grammar_studied,
       vocabulary_studied: base.facts.vocab_studied,
       current_streak: base.facts.streak,
-      total_badges: base.facts.total_badges,
       weekly_streak: base.facts.weekly_streak.map(day => ({ day: day.day, studied: day.val }))
     },
     jlpt_progress: JLPT_KEYS.map(key => {

--- a/src/bunpro/schemas.ts
+++ b/src/bunpro/schemas.ts
@@ -213,3 +213,88 @@ export const RecentActivityOutputSchema = z.object({
 
 export type RecentActivityInput = z.infer<typeof RecentActivityInputSchema>;
 export type RecentActivityOutput = z.infer<typeof RecentActivityOutputSchema>;
+
+const SrsStageCountsSchema = z.object({
+  beginner: z.number().int().nonnegative(),
+  seasoned: z.number().int().nonnegative(),
+  adept: z.number().int().nonnegative(),
+  expert: z.number().int().nonnegative(),
+  master: z.number().int().nonnegative(),
+  total_count: z.number().int().nonnegative()
+});
+
+const ReviewAggregateSchema = z.object({
+  accuracy: z.number(),
+  correct: z.number().int().nonnegative(),
+  incorrect: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative()
+});
+
+export const LearningProgressOutputSchema = z.object({
+  retrieved_at: z.string().datetime(),
+  base: z.object({
+    days_studied: z.number().int().nonnegative(),
+    grammar_studied: z.number().int().nonnegative(),
+    vocabulary_studied: z.number().int().nonnegative(),
+    current_streak: z.number().int().nonnegative(),
+    total_badges: z.number().int().nonnegative(),
+    weekly_streak: z.array(z.object({ day: z.string(), studied: z.boolean() }))
+  }),
+  jlpt_progress: z.array(z.object({
+    jlpt_level: z.enum(["N5", "N4", "N3", "N2", "N1"]),
+    grammar: SrsStageCountsSchema,
+    vocabulary: SrsStageCountsSchema,
+    combined: SrsStageCountsSchema.extend({ derived: z.literal(true) })
+  })).length(5),
+  review_totals: z.array(z.object({
+    jlpt_level: z.enum(["N5", "N4", "N3", "N2", "N1"]),
+    grammar: ReviewAggregateSchema,
+    vocabulary: ReviewAggregateSchema,
+    mixed: ReviewAggregateSchema.extend({ source_supplied: z.literal(true) })
+  })).length(5),
+  cram: z.object({
+    items: ReviewAggregateSchema,
+    sessions: z.object({
+      average_time: z.string(),
+      reviews_per_session: z.number().int().nonnegative(),
+      session_count: z.number().int().nonnegative(),
+      total_time: z.string()
+    })
+  })
+});
+
+export type LearningProgress = z.infer<typeof LearningProgressOutputSchema>;
+
+export const ActivityTrendOutputSchema = z.object({
+  requested_start_date: IsoDateSchema,
+  requested_end_date: IsoDateSchema,
+  source_timezone: z.string().min(1),
+  expected_timezone: z.string().min(1).nullable(),
+  timezone_matches: z.boolean().nullable(),
+  overall_query_status: z.enum(["complete", "partial"]),
+  days: z.array(StudyDayEvidenceSchema).max(93),
+  metrics: z.object({
+    reviews: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      total: z.number().int().nonnegative(),
+      average_per_source_record_day: z.number().nullable()
+    }),
+    new_content: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      total: z.number().int().nonnegative(),
+      average_per_source_record_day: z.number().nullable()
+    }),
+    accuracy: z.object({
+      source_record_days: z.number().int().nonnegative(),
+      average_percent: z.number().nullable()
+    })
+  }),
+  derived_measures_labeled: z.literal(true),
+  source_coverage: z.object({
+    reviews: SourceCoverageSchema,
+    new_content: SourceCoverageSchema,
+    accuracy: SourceCoverageSchema
+  })
+});
+
+export type ActivityTrend = z.infer<typeof ActivityTrendOutputSchema>;

--- a/src/bunpro/schemas.ts
+++ b/src/bunpro/schemas.ts
@@ -224,7 +224,7 @@ const SrsStageCountsSchema = z.object({
 });
 
 const ReviewAggregateSchema = z.object({
-  accuracy: z.number(),
+  accuracy: z.number().min(0).max(100),
   correct: z.number().int().nonnegative(),
   incorrect: z.number().int().nonnegative(),
   total: z.number().int().nonnegative()
@@ -237,8 +237,7 @@ export const LearningProgressOutputSchema = z.object({
     grammar_studied: z.number().int().nonnegative(),
     vocabulary_studied: z.number().int().nonnegative(),
     current_streak: z.number().int().nonnegative(),
-    total_badges: z.number().int().nonnegative(),
-    weekly_streak: z.array(z.object({ day: z.string(), studied: z.boolean() }))
+    weekly_streak: z.array(z.object({ day: z.string(), studied: z.boolean() })).max(7)
   }),
   jlpt_progress: z.array(z.object({
     jlpt_level: z.enum(["N5", "N4", "N3", "N2", "N1"]),

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ export type BunproClientFactory = () => BunproAccountAccess;
 export function createServer(
   clientFactory: BunproClientFactory = () => new BunproClient(apiTokenFromEnvironment())
 ): McpServer {
-  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.1.0" });
+  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.2.0" });
   let sharedClient: BunproAccountAccess | undefined;
   const getClient = (): BunproAccountAccess => {
     sharedClient ??= clientFactory();

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,10 +12,13 @@ import {
   ListStudyDecksInputSchema,
   ListStudyDecksOutputSchema,
   RecentActivityInputSchema,
-  RecentActivityOutputSchema
+  RecentActivityOutputSchema,
+  LearningProgressOutputSchema,
+  ActivityTrendOutputSchema
 } from "./bunpro/schemas.js";
 import { getStudyDaySummary, getStudyRangeSummary } from "./bunpro/study.js";
 import { getRecentActivity, getReviewSchedule, listStudyDecks } from "./bunpro/planning.js";
+import { getActivityTrend, getLearningProgress } from "./bunpro/progress.js";
 
 export interface BunproAccountAccess {
   checkConnection(operationSignal?: AbortSignal): Promise<ConnectionStatus>;
@@ -207,6 +210,68 @@ export function createServer(
     async input => {
       try {
         const structuredContent = await getRecentActivity(getClient(), input);
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_learning_progress",
+    {
+      title: "Get Bunpro learning progress",
+      description:
+        "Return normalized account study facts, JLPT N5-N1 SRS-stage progress, JLPT review totals, and cram aggregates without badge or profile details.",
+      inputSchema: z.object({}).strict(),
+      outputSchema: LearningProgressOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async () => {
+      try {
+        const structuredContent = await getLearningProgress(getClient());
+        return {
+          content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
+          structuredContent
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: connectionErrorMessage(error) }]
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "get_activity_trend",
+    {
+      title: "Get Bunpro activity trend",
+      description:
+        "Return preserved daily review, new-content, and accuracy evidence plus explicitly derived totals and source-present-day averages for a range of at most 93 days.",
+      inputSchema: StudyRangeInputSchema,
+      outputSchema: ActivityTrendOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true
+      }
+    },
+    async input => {
+      try {
+        const structuredContent = await getActivityTrend(getClient(), input);
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent

--- a/tests/progress-tools.test.ts
+++ b/tests/progress-tools.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/client";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+import { createHttpMcpHandler } from "../src/http-server.js";
+import type { FetchLike } from "../src/bunpro/client.js";
+
+async function withMcpClient(
+  fetchImplementation: FetchLike,
+  run: (client: Client) => Promise<void>
+): Promise<void> {
+  const handler = createHttpMcpHandler(fetchImplementation);
+  const transport = new StreamableHTTPClientTransport(new URL("https://mcp.example/mcp"), {
+    authProvider: { token: async () => "account-token" },
+    fetch: (input, init) => handler.fetch(new Request(input, init))
+  });
+  const client = new Client({ name: "progress-tools-test", version: "0.1.0" });
+  try {
+    await client.connect(transport);
+    await run(client);
+  } finally {
+    await client.close();
+    await handler.close();
+  }
+}
+
+function fixtureFetch(fixtures: Record<string, unknown>, paths: string[]): FetchLike {
+  return async input => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    paths.push(url.pathname);
+    const fixture = fixtures[url.pathname];
+    return fixture === undefined ? new Response("not found", { status: 404 }) : Response.json(fixture);
+  };
+}
+
+const userFixture = { user: { data: { attributes: { time_zone_iana: "Asia/Kolkata" } } } };
+const stages = (offset: number) => ({
+  beginner: offset + 1,
+  adept: offset + 2,
+  seasoned: offset + 3,
+  expert: offset + 4,
+  master: offset + 5,
+  total_count: offset + 20
+});
+const reviewStats = (offset: number) => ({
+  accuracy: 80 + offset,
+  correct: 8 + offset,
+  incorrect: 2,
+  total: 10 + offset,
+  global: 999
+});
+
+test("get_learning_progress normalizes JLPT progress and omits unrelated or unexplained fields", async () => {
+  const paths: string[] = [];
+  const levels = Object.fromEntries([1, 2, 3, 4, 5].map(level => [String(level), stages(level)]));
+  const totals = Object.fromEntries([1, 2, 3, 4, 5].map(level => [String(level), reviewStats(level)]));
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user_stats/base_stats": {
+      facts: {
+        days_studied: 30,
+        grammar_studied: 120,
+        vocab_studied: 50,
+        streak: 7,
+        total_badges: 9,
+        last_session: 123456,
+        weekly_streak: [{ day: "Mon", val: true }, { day: "Tue", val: false }]
+      },
+      badges: { data: [{ id: "private-badge" }] }
+    },
+    "/api/frontend/user_stats/jlpt_progress_mixed": { grammar: levels, vocab: levels },
+    "/api/frontend/user_stats/total_review_stats": {
+      grammar: totals,
+      vocab: totals,
+      mixed: totals
+    },
+    "/api/frontend/user_stats/total_cram_stats": {
+      items: { accuracy: 75, correct: 30, incorrect: 10, total: 40 },
+      sessions: {
+        average_time: "00:10:00",
+        reviews_per_session: 20,
+        session_count: 2,
+        total_time: "00:20:00"
+      }
+    }
+  }, paths);
+
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({ name: "get_learning_progress", arguments: {} });
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.deepEqual(output.base, {
+      days_studied: 30,
+      grammar_studied: 120,
+      vocabulary_studied: 50,
+      current_streak: 7,
+      total_badges: 9,
+      weekly_streak: [{ day: "Mon", studied: true }, { day: "Tue", studied: false }]
+    });
+    assert.deepEqual(output.jlpt_progress.map((item: any) => item.jlpt_level), ["N5", "N4", "N3", "N2", "N1"]);
+    assert.equal(output.jlpt_progress[0].combined.derived, true);
+    assert.equal(output.jlpt_progress[0].combined.beginner, 12);
+    assert.equal(output.review_totals[0].jlpt_level, "N5");
+    assert.equal(output.review_totals[0].mixed.source_supplied, true);
+    assert.deepEqual(output.cram.items, { accuracy: 75, correct: 30, incorrect: 10, total: 40 });
+    assert.doesNotMatch(JSON.stringify(output), /private-badge|last_session|global/);
+    assert.deepEqual(paths, [
+      "/api/frontend/user",
+      "/api/frontend/user_stats/base_stats",
+      "/api/frontend/user_stats/jlpt_progress_mixed",
+      "/api/frontend/user_stats/total_review_stats",
+      "/api/frontend/user_stats/total_cram_stats"
+    ]);
+  });
+});
+
+test("get_activity_trend preserves daily evidence and averages only source-present records", async () => {
+  const paths: string[] = [];
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user_stats/review_heatmap": {
+      grammar: { "2026-08-10": 3, "2026-08-11": 4 },
+      vocab: { "2026-08-10": 2 },
+      mixed: { "2026-08-10": 5, "2026-08-11": 4 }
+    },
+    "/api/frontend/user_stats/new_content_heatmap": {
+      grammar: { "2026-08-10": 1 },
+      vocab: { "2026-08-10": 2 },
+      mixed: { "2026-08-10": 3 }
+    },
+    "/api/frontend/user_stats/accuracy_over_time": {
+      "2026-08-10": 80,
+      "2026-08-11": 100
+    }
+  }, paths);
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({
+      name: "get_activity_trend",
+      arguments: { start_date: "2026-08-10", end_date: "2026-08-12" }
+    });
+    assert.equal(result.isError, undefined);
+    const output = result.structuredContent as Record<string, any>;
+    assert.deepEqual(output.metrics, {
+      reviews: { source_record_days: 2, total: 9, average_per_source_record_day: 4.5 },
+      new_content: { source_record_days: 1, total: 3, average_per_source_record_day: 3 },
+      accuracy: { source_record_days: 2, average_percent: 90 }
+    });
+    assert.equal(output.derived_measures_labeled, true);
+    assert.equal(output.days.length, 3);
+    assert.equal(output.days[2].reviews.coverage, "no_source_record");
+    assert.deepEqual(paths, [
+      "/api/frontend/user",
+      "/api/frontend/user_stats/review_heatmap",
+      "/api/frontend/user_stats/new_content_heatmap",
+      "/api/frontend/user_stats/accuracy_over_time"
+    ]);
+  });
+});
+
+test("get_learning_progress fails closed when Bunpro changes its JLPT groups", async () => {
+  const paths: string[] = [];
+  const incompleteLevels = Object.fromEntries([2, 3, 4, 5].map(level => [String(level), stages(level)]));
+  const completeLevels = Object.fromEntries([1, 2, 3, 4, 5].map(level => [String(level), reviewStats(level)]));
+  const fetch = fixtureFetch({
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user_stats/base_stats": {
+      facts: {
+        days_studied: 1,
+        grammar_studied: 1,
+        vocab_studied: 1,
+        streak: 1,
+        total_badges: 0,
+        weekly_streak: []
+      }
+    },
+    "/api/frontend/user_stats/jlpt_progress_mixed": {
+      grammar: incompleteLevels,
+      vocab: incompleteLevels
+    },
+    "/api/frontend/user_stats/total_review_stats": {
+      grammar: completeLevels,
+      vocab: completeLevels,
+      mixed: completeLevels
+    },
+    "/api/frontend/user_stats/total_cram_stats": {
+      items: { accuracy: 0, correct: 0, incorrect: 0, total: 0 },
+      sessions: {
+        average_time: "00:00:00",
+        reviews_per_session: 0,
+        session_count: 0,
+        total_time: "00:00:00"
+      }
+    }
+  }, paths);
+
+  await withMcpClient(fetch, async client => {
+    const result = await client.callTool({ name: "get_learning_progress", arguments: {} });
+    assert.equal(result.isError, true);
+    const message = result.content
+      .filter(item => item.type === "text")
+      .map(item => item.text)
+      .join("\n");
+    assert.match(message, /unexpected JLPT level groups/i);
+    assert.doesNotMatch(message, /account-token|beginner|global/i);
+  });
+});

--- a/tests/progress-tools.test.ts
+++ b/tests/progress-tools.test.ts
@@ -94,7 +94,6 @@ test("get_learning_progress normalizes JLPT progress and omits unrelated or unex
       grammar_studied: 120,
       vocabulary_studied: 50,
       current_streak: 7,
-      total_badges: 9,
       weekly_streak: [{ day: "Mon", studied: true }, { day: "Tue", studied: false }]
     });
     assert.deepEqual(output.jlpt_progress.map((item: any) => item.jlpt_level), ["N5", "N4", "N3", "N2", "N1"]);
@@ -103,7 +102,7 @@ test("get_learning_progress normalizes JLPT progress and omits unrelated or unex
     assert.equal(output.review_totals[0].jlpt_level, "N5");
     assert.equal(output.review_totals[0].mixed.source_supplied, true);
     assert.deepEqual(output.cram.items, { accuracy: 75, correct: 30, incorrect: 10, total: 40 });
-    assert.doesNotMatch(JSON.stringify(output), /private-badge|last_session|global/);
+    assert.doesNotMatch(JSON.stringify(output), /private-badge|total_badges|last_session|global/);
     assert.deepEqual(paths, [
       "/api/frontend/user",
       "/api/frontend/user_stats/base_stats",
@@ -204,3 +203,78 @@ test("get_learning_progress fails closed when Bunpro changes its JLPT groups", a
     assert.doesNotMatch(message, /account-token|beginner|global/i);
   });
 });
+
+test("get_learning_progress rejects out-of-range accuracy", async () => {
+  const paths: string[] = [];
+  const fixtures = validProgressFixtures();
+  const reviewTotals = fixtures["/api/frontend/user_stats/total_review_stats"] as any;
+  reviewTotals.grammar[5].accuracy = 175;
+
+  await withMcpClient(fixtureFetch(fixtures, paths), async client => {
+    const result = await client.callTool({ name: "get_learning_progress", arguments: {} });
+    assert.equal(result.isError, true);
+    const message = result.content
+      .filter(item => item.type === "text")
+      .map(item => item.text)
+      .join("\n");
+    assert.match(message, /response shape changed/i);
+    assert.doesNotMatch(message, /175|account-token/i);
+  });
+});
+
+test("get_learning_progress rejects an oversized weekly streak", async () => {
+  const paths: string[] = [];
+  const fixtures = validProgressFixtures();
+  const base = fixtures["/api/frontend/user_stats/base_stats"] as any;
+  base.facts.weekly_streak = Array.from({ length: 8 }, (_, index) => ({
+    day: `day-${index}`,
+    val: index % 2 === 0
+  }));
+
+  await withMcpClient(fixtureFetch(fixtures, paths), async client => {
+    const result = await client.callTool({ name: "get_learning_progress", arguments: {} });
+    assert.equal(result.isError, true);
+    const message = result.content
+      .filter(item => item.type === "text")
+      .map(item => item.text)
+      .join("\n");
+    assert.match(message, /response shape changed/i);
+    assert.doesNotMatch(message, /day-7|account-token/i);
+  });
+});
+
+function validProgressFixtures(): Record<string, unknown> {
+  const levelStages = Object.fromEntries([1, 2, 3, 4, 5].map(level => [String(level), stages(level)]));
+  const totals = Object.fromEntries([1, 2, 3, 4, 5].map(level => [String(level), reviewStats(level)]));
+  return {
+    "/api/frontend/user": userFixture,
+    "/api/frontend/user_stats/base_stats": {
+      facts: {
+        days_studied: 10,
+        grammar_studied: 20,
+        vocab_studied: 30,
+        streak: 2,
+        total_badges: 1,
+        weekly_streak: [{ day: "Mon", val: true }]
+      }
+    },
+    "/api/frontend/user_stats/jlpt_progress_mixed": {
+      grammar: levelStages,
+      vocab: levelStages
+    },
+    "/api/frontend/user_stats/total_review_stats": {
+      grammar: totals,
+      vocab: totals,
+      mixed: totals
+    },
+    "/api/frontend/user_stats/total_cram_stats": {
+      items: { accuracy: 75, correct: 30, incorrect: 10, total: 40 },
+      sessions: {
+        average_time: "00:10:00",
+        reviews_per_session: 20,
+        session_count: 2,
+        total_time: "00:20:00"
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add learning-progress and activity-trend tools with strict source/output schemas
- add deterministic synthetic evaluations and a paced all-tools live smoke
- prepare a public hosted-service announcement while preserving the private implementation boundary
- harden accuracy, weekly-streak, and cosmetic-field contracts after review

## Verification
- TypeScript test typecheck
- 32 automated tests
- production build
- secret scan and public-draft disclosure scan

The repository and pull request must remain private.