### PR TITLE
Support hosted tool smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ The opt-in live connection test uses your own Account API Token and performs rea
 BUNPRO_API_TOKEN="your token" npm run live:test:auth
 BUNPRO_API_TOKEN="your token" npm run live:test:http
 BUNPRO_API_TOKEN="your token" npm run live:test:tools
+BUNPRO_API_TOKEN="your token" BUNPRO_MCP_URL="https://your-host.example/mcp" npm run live:test:tools
 ```
 
-The first command tests stdio. The second tests the HTTP Bearer-token passthrough. The third makes one deliberately paced pass through every published tool. All use the real Bunpro API without opening a network listener, and the tool sweep prints only tool names and success states. Do not attach raw Bunpro responses or secrets to issues.
+The first command tests stdio. The second tests the HTTP Bearer-token passthrough. The third makes one deliberately paced pass through every published tool in process; adding `BUNPRO_MCP_URL` runs the same sweep against a deployed Streamable HTTP endpoint. All use the real Bunpro API, and the tool sweep prints only tool names and success states. Do not attach raw Bunpro responses or secrets to issues.
 
 ## Contributing
 

--- a/scripts/live-all-tools-smoke.ts
+++ b/scripts/live-all-tools-smoke.ts
@@ -5,10 +5,13 @@ import { createHttpMcpHandler } from "../src/http-server.js";
 const apiToken = process.env.BUNPRO_API_TOKEN;
 assert.ok(apiToken, "BUNPRO_API_TOKEN must be configured for the live tool smoke test.");
 
-const handler = createHttpMcpHandler();
-const transport = new StreamableHTTPClientTransport(new URL("https://local-smoke.invalid/mcp"), {
+const remoteUrl = process.env.BUNPRO_MCP_URL;
+const handler = remoteUrl === undefined ? createHttpMcpHandler() : undefined;
+const transport = new StreamableHTTPClientTransport(new URL(remoteUrl ?? "https://local-smoke.invalid/mcp"), {
   authProvider: { token: async () => apiToken },
-  fetch: (input, init) => handler.fetch(new Request(input, init))
+  fetch: handler === undefined
+    ? fetch
+    : (input, init) => handler.fetch(new Request(input, init))
 });
 const client = new Client({ name: "bunpro-mcp-all-tools-smoke", version: "0.1.0" });
 
@@ -44,7 +47,7 @@ try {
   });
 } finally {
   await client.close();
-  await handler.close();
+  await handler?.close();
 }
 
 async function call(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- allow the paced all-tools smoke to target a deployed Streamable HTTP endpoint
- document the hosted smoke invocation

## Verification
- test TypeScript typecheck
- diff check

Repository remains private.