### PR TITLE
Prepare private repository for a future public-source release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@
 BUNPRO_API_TOKEN=
 
 # Railway HTTP mode. Each MCP caller supplies its own Bunpro Account API Token
-# as the connection's Bearer token; do not configure a shared token here.
+# through the protected X-Bunpro-Token header; do not configure a shared token here.
 TRANSPORT=http
 PUBLIC_BASE_URL=https://bunpro.yashkadam.com

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Never include Bunpro credentials, cookies, frontend tokens, OAuth tokens, setup links, encryption keys, database URLs, or raw Bunpro responses.
+        Never include a Bunpro token, token-bearing header, credential screenshot, raw Bunpro response, personal study data, setup link, encryption key, or database URL. Rotate an exposed token before continuing.
   - type: textarea
     id: summary
     attributes:
@@ -28,14 +28,14 @@ body:
     id: client
     attributes:
       label: MCP client
-      description: For example, ChatGPT desktop, Codex CLI, or Claude Desktop.
+      description: For example, ChatGPT desktop, Codex, or Claude Desktop.
     validations:
       required: true
   - type: input
     id: version
     attributes:
       label: Bunpro MCP commit or version
-      placeholder: 0.1.0 or a commit SHA
+      placeholder: 0.3.1 or a commit SHA
     validations:
       required: true
   - type: input
@@ -43,25 +43,32 @@ body:
     attributes:
       label: Node.js version
       description: Required for local or self-hosted reports.
+  - type: input
+    id: tool
+    attributes:
+      label: Affected tool
+      placeholder: get_connection_status
+    validations:
+      required: true
   - type: textarea
     id: reproduction
     attributes:
       label: Reproduction steps
-      description: Provide the smallest sequence that reproduces the problem without real account data.
+      description: Provide the smallest sequence that reproduces the problem using synthetic examples only.
     validations:
       required: true
   - type: textarea
     id: error
     attributes:
-      label: Sanitized error
-      description: Remove all credentials, tokens, setup URLs, personal data, and raw response bodies.
+      label: Sanitized error and approximate time
+      description: Include the time and timezone. Remove every credential, token, header, personal value, and raw response body.
       render: text
   - type: checkboxes
     id: checks
     attributes:
       label: Safety checks
       options:
-        - label: I removed all secrets, personal data, setup links, and raw Bunpro responses.
+        - label: I removed all secrets, headers, personal data, setup links, screenshots, and raw Bunpro responses.
           required: true
-        - label: I searched existing issues and read the troubleshooting and security guidance.
+        - label: I searched existing issues and read the troubleshooting, support, and security guidance.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability privately
     url: https://github.com/yash-278/bunpro-mcp/security/advisories/new
-    about: Never disclose credentials, tokens, setup links, or vulnerability details in a public issue.
+    about: Never disclose credentials, tokens, headers, setup links, or vulnerability details in a public issue.
+  - name: Setup and troubleshooting
+    url: https://bunpro.yashkadam.com/#help
+    about: Check the hosted setup guide and common fixes before opening an issue.
+  - name: Hosted service health
+    url: https://bunpro.yashkadam.com/healthz
+    about: Confirm whether the public service process is reachable.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Bunpro MCP is intentionally read-only. Requests that submit reviews, change progress, or modify a Bunpro account are out of scope.
+        Bunpro MCP is intentionally read only. Requests that submit reviews, change progress, or modify a Bunpro account are out of scope. Do not include private API details, tokens, raw responses, or personal study data.
   - type: textarea
     id: problem
     attributes:
@@ -25,7 +25,9 @@ body:
     id: evidence
     attributes:
       label: Read-only source evidence
-      description: If known, describe the Bunpro read surface without including raw personal responses.
+      description: Which user-visible Bunpro information would support the answer? Do not describe private routes, schemas, or raw responses.
+    validations:
+      required: true
   - type: textarea
     id: limitations
     attributes:
@@ -36,7 +38,7 @@ body:
     attributes:
       label: Scope checks
       options:
-        - label: This request is read-only and does not modify a Bunpro account.
+        - label: This request is read only and does not modify a Bunpro account.
           required: true
-        - label: This issue contains no credentials, tokens, personal data, or raw Bunpro responses.
+        - label: This issue contains no private API details, credentials, personal data, or raw Bunpro responses.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,13 +8,19 @@ Explain the user problem or compatibility issue.
 
 ## Safety and privacy
 
-- [ ] Bunpro interaction remains read-only.
-- [ ] No credentials, cookies, tokens, setup links, personal data, or raw Bunpro responses are included.
+- [ ] Bunpro interaction remains read only.
+- [ ] No credentials, cookies, tokens, headers, setup links, personal data, confidential correspondence, or raw Bunpro responses are included.
 - [ ] Tool schemas, annotations, and errors match the implemented behavior.
-- [ ] Privacy, security, or setup documentation was updated when behavior changed.
+- [ ] Privacy, security, support, or setup documentation was updated when behavior changed.
+- [ ] The repository remains private and this change publishes no source artifact or private implementation detail.
 
 ## Verification
 
 - [ ] `npm run check` passes.
 - [ ] New or changed behavior has automated tests.
+- [ ] Tests use synthetic fixtures only.
 - [ ] Any live test used only an authorized account and emitted sanitized output.
+
+## Deployment impact
+
+State whether Railway configuration, caller configuration, or public documentation changes are required.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,18 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Kolkata
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore
+      include: scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+Notable changes to Bunpro MCP are recorded here. The project follows semantic versioning while it remains in private preview.
+
+## 0.3.1 — 2026-08-24
+
+- Added a public, responsive setup and product homepage at `https://bunpro.yashkadam.com/`.
+- Added repository support guidance, contribution templates, dependency-update configuration, and an explicit future public-source release gate.
+
+## 0.3.0 — 2026-08-12
+
+- Added `X-Bunpro-Token` as the preferred hosted credential header, accepting the raw Account API Token without a prefix.
+- Retained `Authorization: Bearer ...` for existing connections and rejected ambiguous dual credentials.
+- Updated hosted setup, privacy, security, and community documentation.
+
+## 0.2.0 — 2026-08-12
+
+- Completed the eight-tool read-only catalog for connection checks, study summaries, schedules, decks, recent activity, progress, and trends.
+- Added bounded schemas, source-coverage semantics, synthetic evaluations, and full transport verification.
+
+## 0.1.0 — 2026-08-12
+
+- Added stateless stdio and Streamable HTTP transports.
+- Added direct per-caller Account API Token passthrough with no credential database, cookies, or login scraping.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,7 +10,7 @@ Bunpro's private, undocumented `/api/frontend/*` interface. Its routes, response
 
 ## Direct Token Passthrough
 
-The remote MCP host sends the caller's Account API Token in the HTTP Bearer header. The MCP reads that value for one request, translates it into Bunpro's expected Account API Token header, and does not persist it. Local stdio obtains the same token from `BUNPRO_API_TOKEN`.
+The remote MCP host sends the caller's Account API Token in the protected `X-Bunpro-Token` header. `Authorization: Bearer ...` remains a compatibility path for existing connections. The MCP reads exactly one of those values for one request, translates it into Bunpro's expected Account API Token header, and does not persist it. Local stdio obtains the same token from `BUNPRO_API_TOKEN`.
 
 ## Token-Authenticated Frontend Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thanks for helping improve Bunpro MCP.
 - For a Bunpro compatibility problem, say when it occurred and which read-only workflow failed without pasting the response body.
 
 Security issues belong in the private process described in [SECURITY.md](SECURITY.md).
+General setup and usage questions belong in the process described in [SUPPORT.md](SUPPORT.md).
 
 ## Development setup
 
@@ -33,3 +34,7 @@ npm run check
 - Update the README, privacy disclosure, or self-hosting guide when behavior changes.
 
 Run `npm run check` before submitting a pull request.
+
+## Publication boundary
+
+The hosted MCP may be used publicly, but the repository must remain private until Bunpro gives written permission that specifically allows public disclosure of the temporary integration mechanism. Do not publish source excerpts, packages, containers, mirrors, or implementation documentation from this repository. See [AGENTS.md](AGENTS.md) and [the source-release gate](docs/public-source-release.md).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ The first command tests stdio. The second tests the HTTP `X-Bunpro-Token` passth
 
 ## Contributing
 
-Bug reports, compatibility reports, and focused pull requests are welcome within the private project. Read [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+Bug reports, compatibility reports, and focused pull requests are welcome within the private project. Read [CONTRIBUTING.md](CONTRIBUTING.md), [SUPPORT.md](SUPPORT.md), and the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+
+Release history is recorded in [CHANGELOG.md](CHANGELOG.md). The repository's future public-source release remains gated by the Bunpro permission requirements in [docs/public-source-release.md](docs/public-source-release.md).
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,22 @@
+# Support
+
+## Setup and usage help
+
+Before reporting a problem:
+
+1. Confirm the hosted health check returns `{"status":"ok"}` at `https://bunpro.yashkadam.com/healthz`.
+2. Confirm the MCP URL is exactly `https://bunpro.yashkadam.com/mcp`.
+3. Confirm the protected header name is exactly `X-Bunpro-Token` and its value contains only the current Bunpro Account API Token.
+4. Start a new chat with Bunpro MCP enabled and ask: `Check my Bunpro connection.`
+
+For a normal bug, use the repository's bug-report form. Include the client, transport, Node.js version when self-hosting, approximate time, affected tool, and sanitized error message.
+
+Never include an Account API Token, token-bearing header, credential screenshot, raw Bunpro response, or personal study data. If a token was exposed, rotate it in Bunpro Settings → API before doing anything else.
+
+## Security problems
+
+Do not open a public issue. Use GitHub private vulnerability reporting as described in [SECURITY.md](SECURITY.md).
+
+## Service expectations
+
+This is an unofficial, experimental, best-effort community service. Bunpro may change or restrict the temporary interface without notice. The maintainer may limit or pause the hosted service to protect Bunpro from excessive traffic.

--- a/docs/public-source-release.md
+++ b/docs/public-source-release.md
@@ -1,0 +1,41 @@
+# Public-source release gate
+
+The hosted Bunpro MCP is a public community product. The source repository is not currently authorized for public disclosure and must remain private.
+
+## Blocking approval
+
+Before changing repository visibility or publishing any source artifact, obtain new written permission from Bunpro that explicitly covers all intended channels:
+
+- a public GitHub repository containing the temporary integration code;
+- public disclosure of the request mechanism, route names, and authentication translation present in source and technical documentation;
+- any package registry, container registry, mirror, generated documentation site, or downloadable release artifact; and
+- any public forum announcement that links to or explains the source implementation.
+
+Store the approval privately. Record only its date, approver, authorized scope, and durable private reference in the release issue; do not commit confidential correspondence.
+
+General encouragement, permission to operate the hosted service, ownership of the repository, or permission to include code in a repository without permission to publicly disclose the mechanism does not satisfy this gate.
+
+## Preparation complete while private
+
+- [x] MIT license and copyright notice.
+- [x] README with capabilities, local and hosted setup, limitations, and trust boundary.
+- [x] Security, privacy, support, contribution, and conduct policies.
+- [x] Bug, feature, and pull-request templates that prohibit credential disclosure.
+- [x] CI on supported Node.js versions and weekly dependency update configuration.
+- [x] Stateless, read-only tools with strict schemas, bounded responses, timeouts, and sanitized failures.
+- [x] Docker and Railway deployment configuration with no database or deployment-wide Bunpro credential.
+- [x] Public hosted service and health check.
+- [x] Repository-level guardrail that blocks accidental visibility and artifact publication.
+
+## Actions permitted only after approval
+
+1. Review the written permission against each intended publication channel.
+2. Decide whether private research notes and superseded authentication ADRs are within scope; remove them from the public history if they are not.
+3. Scan the complete Git history for credentials, private correspondence, raw account data, and out-of-scope implementation details.
+4. Re-run `npm ci`, `npm run check`, dependency auditing, the synthetic evaluation, and a low-volume hosted smoke test.
+5. Verify branch protection, private vulnerability reporting, issue settings, and least-privilege workflow permissions.
+6. Keep `package.json` marked `private` unless package-registry publication is separately approved.
+7. Change visibility only after a final maintainer review, then verify the repository and all artifacts expose only the authorized scope.
+8. Re-check the Railway deployment and public disclosures after the visibility change.
+
+If approval is narrower than this plan, narrow the release to match it. Do not infer permission for another channel.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -15,13 +15,13 @@ The hosted MCP may be announced publicly. The repository and Bunpro-specific req
 
 - [x] Railway deploys automatically from the private repository's `main` branch.
 - [x] Set `PUBLIC_BASE_URL=https://bunpro.yashkadam.com`.
-- [ ] Remove obsolete Auth0, database, encryption-key, setup-token, username, password, and deployment-wide Bunpro token variables.
+- [x] Remove obsolete Auth0, database, encryption-key, setup-token, username, password, and deployment-wide Bunpro token variables. Verified on Railway by variable name on 2026-08-24; only platform metadata, `NODE_ENV`, `PUBLIC_BASE_URL`, and `TRANSPORT` remain.
 - [x] Confirm `GET /healthz` returns HTTP 200 on the canonical domain.
 - [x] Confirm the generated Railway domain is not an alternate public entry point after the canonical domain works.
 - [x] Confirm a missing, malformed, or ambiguous token header receives HTTP 401 without leaking request data.
 - [x] Run one low-volume live smoke pass across every published tool with a valid caller token.
 - [x] Confirm one invalid token produces a sanitized authentication error.
-- [ ] Review edge rate limits and abuse controls without logging token-bearing headers or response bodies.
+- [x] Review edge rate limits and abuse controls without logging token-bearing headers or response bodies. The shared upstream gate permits four active calls and sixteen queued calls, request and response sizes are bounded, calls time out, and rate-limited requests are not retried automatically. No caller identity or token-derived rate-limit record is stored.
 
 ## Product behavior
 
@@ -39,5 +39,7 @@ The hosted MCP may be announced publicly. The repository and Bunpro-specific req
 - [x] The draft does not link to or describe how to reproduce the private implementation.
 - [x] Reader-test [the public announcement draft](community-post.md) for clarity and accidental disclosure.
 - [ ] Publish only after every hosted-service gate above is complete.
+
+The hosted-service gates are complete as of 2026-08-24. Publishing this community announcement does not authorize changing the repository visibility or publishing the source. See [the separate public-source release gate](public-source-release.md).
 
 Atlas integration is intentionally out of scope for this release. Do not edit the Atlas vault or infer an Atlas watermark from MCP output during release work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bunpro-mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Unofficial stateless, read-only Bunpro MCP with direct Account API Token passthrough",
   "type": "module",
   "private": true,

--- a/src/bunpro/progress.ts
+++ b/src/bunpro/progress.ts
@@ -124,9 +124,10 @@ export async function getLearningProgress(
 
 export async function getActivityTrend(
   source: StudySource,
-  input: StudyRangeInput
+  input: StudyRangeInput,
+  now: Date = new Date()
 ): Promise<ActivityTrend> {
-  const range = await getStudyRangeSummary(source, input);
+  const range = await getStudyRangeSummary(source, input, now);
   const reviewCount = range.aggregates.reviews.source_record_days;
   const newContentCount = range.aggregates.new_content.source_record_days;
   return {

--- a/src/homepage.ts
+++ b/src/homepage.ts
@@ -448,6 +448,7 @@ function faq(): string {
     ["Can it change anything in Bunpro?", "No. All eight published tools are read only. The server does not start or submit reviews, change SRS state, add lessons, run crams, edit decks, or modify account settings."],
     ["Does the website receive my token?", "No. This page is static and contains no token field. You paste the token only into your MCP client's protected credential configuration—not into this website or a chat message."],
     ["Does the server store my data?", "No. This service has no account or saved study-history database. It uses your token and Bunpro data only while answering the current request."],
+    ["Is the source code public?", "Not yet. Bunpro's temporary integration details were shared under a restricted disclosure boundary, so the repository remains private unless Bunpro gives written permission for a public source release."],
     ["Will it work in every ChatGPT account?", "Not necessarily. Developer mode and custom MCP creation availability can depend on your plan, app version, workspace policy, and administrator. Other Streamable HTTP MCP clients may also connect."],
     ["Why are some dates marked as missing?", "Bunpro does not provide the same amount of history for every feature. The answer marks missing information clearly instead of pretending it means zero activity."],
     ["What should I do if I exposed my token?", "Rotate or replace the Account API Token in Bunpro, then update or recreate the protected credential in every MCP client where you configured it."]

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -9,7 +9,7 @@ import {
   HOMEPAGE_SITEMAP,
   renderHomepage
 } from "./homepage.js";
-import { createServer as createBunproMcpServer } from "./server.js";
+import { createServer as createBunproMcpServer, type Clock } from "./server.js";
 
 const MAX_MCP_BODY_BYTES = 1024 * 1024;
 const MAX_MCP_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -129,7 +129,10 @@ export async function startHttpServer(options: StartHttpServerOptions): Promise<
   };
 }
 
-export function createHttpMcpHandler(fetchImplementation: FetchLike = fetch) {
+export function createHttpMcpHandler(
+  fetchImplementation: FetchLike = fetch,
+  clock: Clock = () => new Date()
+) {
   const requestGate = new BunproRequestGate({ maximumConcurrent: 4, maximumQueued: 16 });
   return createMcpHandler(
     context => {
@@ -138,7 +141,8 @@ export function createHttpMcpHandler(fetchImplementation: FetchLike = fetch) {
         () => new BunproClient(credential.token, fetchImplementation, {
           tokenSource: credential.tokenSource,
           requestGate
-        })
+        }),
+        clock
       );
     },
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,11 +26,13 @@ export interface BunproAccountAccess {
 }
 
 export type BunproClientFactory = () => BunproAccountAccess;
+export type Clock = () => Date;
 
 export function createServer(
-  clientFactory: BunproClientFactory = () => new BunproClient(apiTokenFromEnvironment())
+  clientFactory: BunproClientFactory = () => new BunproClient(apiTokenFromEnvironment()),
+  clock: Clock = () => new Date()
 ): McpServer {
-  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.3.0" });
+  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.3.1" });
   let sharedClient: BunproAccountAccess | undefined;
   const getClient = (): BunproAccountAccess => {
     sharedClient ??= clientFactory();
@@ -85,7 +87,7 @@ export function createServer(
     },
     async input => {
       try {
-        const structuredContent = await getStudyDaySummary(getClient(), input);
+        const structuredContent = await getStudyDaySummary(getClient(), input, clock());
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent
@@ -116,7 +118,7 @@ export function createServer(
     },
     async input => {
       try {
-        const structuredContent = await getStudyRangeSummary(getClient(), input);
+        const structuredContent = await getStudyRangeSummary(getClient(), input, clock());
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent
@@ -147,7 +149,7 @@ export function createServer(
     },
     async () => {
       try {
-        const structuredContent = await getReviewSchedule(getClient());
+        const structuredContent = await getReviewSchedule(getClient(), clock());
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent
@@ -240,7 +242,7 @@ export function createServer(
     },
     async () => {
       try {
-        const structuredContent = await getLearningProgress(getClient());
+        const structuredContent = await getLearningProgress(getClient(), clock());
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent
@@ -271,7 +273,7 @@ export function createServer(
     },
     async input => {
       try {
-        const structuredContent = await getActivityTrend(getClient(), input);
+        const structuredContent = await getActivityTrend(getClient(), input, clock());
         return {
           content: [{ type: "text", text: JSON.stringify(structuredContent, null, 2) }],
           structuredContent

--- a/tests/http-service.test.ts
+++ b/tests/http-service.test.ts
@@ -70,6 +70,8 @@ test("the public HTTP service enforces its canonical host and bounded MCP reques
     assert.match(homepage.body, /X-Bunpro-Token/);
     assert.match(homepage.body, /Leave blank/);
     assert.match(homepage.body, /Check my Bunpro connection/);
+    assert.match(homepage.body, /source code public/);
+    assert.match(homepage.body, /repository remains private unless Bunpro gives written permission/);
     assert.doesNotMatch(homepage.body, /Available in ChatGPT|Open in ChatGPT|data-concept=/);
     assert.doesNotMatch(homepage.body, /dangerously_authenticate|\/api\/frontend|Token token=/);
 

--- a/tests/planning-tools.test.ts
+++ b/tests/planning-tools.test.ts
@@ -7,9 +7,10 @@ import type { FetchLike } from "../src/bunpro/client.js";
 
 async function withMcpClient(
   fetchImplementation: FetchLike,
-  run: (client: Client) => Promise<void>
+  run: (client: Client) => Promise<void>,
+  clock: () => Date = () => new Date()
 ): Promise<void> {
-  const handler = createHttpMcpHandler(fetchImplementation);
+  const handler = createHttpMcpHandler(fetchImplementation, clock);
   const transport = new StreamableHTTPClientTransport(new URL("https://mcp.example/mcp"), {
     authProvider: { token: async () => "account-token" },
     fetch: (input, init) => handler.fetch(new Request(input, init))
@@ -67,7 +68,7 @@ test("get_review_schedule separates due-now work from the normalized 14-day fore
       "/api/frontend/user/due",
       "/api/frontend/user_stats/forecast_daily"
     ]);
-  });
+  }, () => new Date("2026-08-12T12:00:00.000Z"));
 });
 
 test("list_study_decks returns bounded active study configuration without unrelated deck metadata", async () => {


### PR DESCRIPTION
## Summary
- add changelog, support guidance, safer issue/PR templates, and scheduled dependency updates
- document the exact Bunpro permission gate that must be satisfied before source publication
- close the verified Railway configuration and abuse-control release gates
- update stale X-Bunpro-Token documentation and add a transparent source-availability FAQ to the hosted homepage
- bump the MCP server to 0.3.1
- inject a clock into time-dependent tool handlers so review-schedule tests remain deterministic

## Verification
- 34 tests passed
- test typecheck and production build passed
- GitHub YAML parsed successfully
- production dependency audit found 0 vulnerabilities
- diff and current-tree credential pattern scans were clean
- Railway variable names were reviewed without exposing values

## Publication boundary
The repository was verified PRIVATE before push. This PR does not change visibility or publish a source artifact. Public source release remains blocked until Bunpro gives new written permission covering the intended disclosure channels.