### PR TITLE
docs: align hosted service guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to Bunpro MCP are recorded here. The project follows semantic versioning while it remains in private preview.
 
+## 0.3.2 — 2026-08-24
+
+- Reworked the README around the public hosted service and removed an unusable public clone path.
+- Clarified on the website and in privacy guidance that the repository remains private and public self-hosting is not currently available.
+- Pointed package metadata at the public product and help pages rather than private GitHub pages.
+
 ## 0.3.1 — 2026-08-24
 
 - Added a public, responsive setup and product homepage at `https://bunpro.yashkadam.com/`.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-This document explains how Bunpro MCP handles the Bunpro Account API Token and study data. It applies to the source code and to the hosted service at `https://bunpro.yashkadam.com/mcp`.
+This document explains how Bunpro MCP handles the Bunpro Account API Token and study data. It applies to the private source project and to the hosted service at `https://bunpro.yashkadam.com/mcp`.
 
 ## Local stdio mode
 
@@ -12,11 +12,11 @@ This document explains how Bunpro MCP handles the Bunpro Account API Token and s
 ## Hosted Streamable HTTP mode
 
 - Your MCP host sends your Account API Token in the HTTPS `X-Bunpro-Token` header.
-- The server transforms it into Bunpro's Account API Token header for that request.
+- The server uses it only to make the Bunpro requests needed to answer that MCP call.
 - The application does not create an identity profile, account link, setup session, or database record.
 - The application does not intentionally log or persist token-bearing request headers, the token, Bunpro response bodies, or study history.
 
-The hosted operator and infrastructure provider can technically inspect application memory or traffic where TLS terminates. Stateless passthrough reduces retained data; it does not eliminate the need to trust the hosted service. Use local mode or self-host if that trust boundary is unacceptable.
+The hosted operator and infrastructure provider can technically inspect application memory or traffic where TLS terminates. Stateless passthrough reduces retained data; it does not eliminate the need to trust the hosted service. If that trust boundary is unacceptable, do not use the hosted service. Public local installation and self-hosting are not available while the source repository remains private.
 
 ## Logs and telemetry
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bunpro MCP
 
-An unofficial, stateless, read-only Model Context Protocol (MCP) server for connecting Bunpro to ChatGPT, Codex, and other MCP clients.
+An unofficial, stateless, read-only Model Context Protocol (MCP) service for asking ChatGPT, Codex, and other MCP clients about your Bunpro studies.
+
+The hosted community service is available at [bunpro.yashkadam.com](https://bunpro.yashkadam.com/). Each person connects with their own Bunpro Account API Token; the service does not use a shared Bunpro account or retain credentials between requests.
 
 > [!IMPORTANT]
 > This private project uses Bunpro's experimental Account API Token support for its undocumented Frontend API. It is not affiliated with or endorsed by Bunpro. Routes, schemas, throttling, and whitelist access may change without notice.
@@ -10,7 +12,7 @@ An unofficial, stateless, read-only Model Context Protocol (MCP) server for conn
 
 ## Project status
 
-The direct Account API Token connection and the complete read-only tool catalog are implemented.
+The hosted MCP is live, and the complete read-only tool catalog is implemented.
 
 Available tools:
 
@@ -31,7 +33,7 @@ All Bunpro requests are read-only. The server does not submit reviews, start les
 
 Open **Bunpro → Settings → API** and copy your Account API Token. Treat it like a password. Do not paste it into chat, tool arguments, repository files, screenshots, logs, or support posts.
 
-## Use the hosted version
+## Connect the hosted version
 
 The hosted Streamable HTTP endpoint is:
 
@@ -51,65 +53,30 @@ There is no Auth0 login, Bunpro password form, account-link page, database, or s
 
 Existing clients configured with `Authorization: Bearer <token>` remain compatible, but new connections should use `X-Bunpro-Token`. Do not configure both headers. Never put the token in the URL or a tool argument.
 
-## Run it locally
+## Source and self-hosting status
 
-Local mode runs over stdio and reads the same Account API Token from the MCP host's secret environment configuration.
+The hosted service is available to Bunpro users, but this source repository is currently private. Bunpro shared the temporary integration details under a restricted disclosure boundary, so the project cannot offer public clone, local-install, package, container, or self-hosting instructions yet.
 
-Requirements:
+A public source release requires new written permission from Bunpro that specifically allows disclosure of the integration mechanism. Until that happens, use the hosted endpoint above. If you have been explicitly invited to this private repository, contributor-only local and deployment instructions remain in [docs/self-hosting.md](docs/self-hosting.md).
 
-- Node.js 20 or newer
-- Git
+## Authentication boundary
 
-```bash
-git clone https://github.com/yash-278/bunpro-mcp.git
-cd bunpro-mcp
-npm ci
-npm run build
-```
-
-Add an **STDIO** MCP server using absolute paths on your machine:
-
-```json
-{
-  "command": "/absolute/path/to/node",
-  "args": ["/absolute/path/to/bunpro-mcp/dist/index.js"],
-  "env": {
-    "BUNPRO_API_TOKEN": "your Bunpro Account API Token"
-  }
-}
-```
-
-Use the MCP client's secret environment fields when available. The MCP does not create cookies, perform a browser login, refresh a session, or write the token to disk.
-
-## Self-host the remote version
-
-The remote transport is stateless Streamable HTTP. It requires no Auth0 tenant, OAuth setup, PostgreSQL service, encryption key, or Bunpro credential configured on the deployment. See [docs/self-hosting.md](docs/self-hosting.md).
-
-Each caller must configure their own Bunpro Account API Token in the connection's `X-Bunpro-Token` protected header. Never set a deployment-wide `BUNPRO_API_TOKEN` for HTTP mode.
-
-## Request contract
-
-For each allowed read-only Frontend API route, the adapter transforms the incoming protected token into Bunpro's temporary request contract:
-
-```http
-GET /api/frontend/<route>?dangerously_authenticate_using_api_token=true
-Authorization: Token token=<account-api-token>
-```
-
-The token remains in request memory only. Missing, malformed, or ambiguous credentials fail with HTTP 401. Bunpro authentication failures, throttling, unavailable routes, and schema drift fail closed without login fallback or automatic retry.
+Each caller supplies their own token through the MCP client's protected credential configuration. The hosted deployment has no shared Bunpro credential. Tokens remain in request memory only; missing, malformed, or ambiguous credentials fail closed.
 
 ## Security and limitations
 
 - The model never receives the Account API Token; the MCP host attaches it at the transport layer.
 - The application does not persist tokens, sessions, cookies, study history, or raw Bunpro responses.
-- A hosted operator and infrastructure provider can technically inspect request memory or traffic termination. Use local mode if that trust boundary is unacceptable.
+- A hosted operator and infrastructure provider can technically inspect request memory or traffic termination. If that trust boundary is unacceptable, do not use the hosted service; public self-hosting is not available while the source remains private.
 - Use HTTPS for every non-local HTTP deployment.
 - Bunpro has announced stricter throttling and a future route whitelist. Keep calls low-volume and do not retry aggressively.
 - Absence of study data is not automatically evidence of zero activity.
 
 See [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md) for the full disclosures.
 
-## Development
+## Private-repository development
+
+The commands below are for invited repository contributors. They are not a public installation path.
 
 ```bash
 npm ci
@@ -127,9 +94,11 @@ BUNPRO_API_TOKEN="your token" BUNPRO_MCP_URL="https://your-host.example/mcp" npm
 
 The first command tests stdio. The second tests the HTTP `X-Bunpro-Token` passthrough. The third makes one deliberately paced pass through every published tool in process; adding `BUNPRO_MCP_URL` runs the same sweep against a deployed Streamable HTTP endpoint. All use the real Bunpro API, and the tool sweep prints only tool names and success states. Do not attach raw Bunpro responses or secrets to issues.
 
-## Contributing
+## Contributing and support
 
-Bug reports, compatibility reports, and focused pull requests are welcome within the private project. Read [CONTRIBUTING.md](CONTRIBUTING.md), [SUPPORT.md](SUPPORT.md), and the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+Bug reports, compatibility reports, and focused pull requests are welcome from people who already have access to the private project. Read [CONTRIBUTING.md](CONTRIBUTING.md), [SUPPORT.md](SUPPORT.md), and the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+
+If you use only the hosted service, do not include your Bunpro token or raw study data in a support message. The public website includes setup help and a token-safe health check.
 
 Release history is recorded in [CHANGELOG.md](CHANGELOG.md). The repository's future public-source release remains gated by the Bunpro permission requirements in [docs/public-source-release.md](docs/public-source-release.md).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ Before reporting a problem:
 3. Confirm the protected header name is exactly `X-Bunpro-Token` and its value contains only the current Bunpro Account API Token.
 4. Start a new chat with Bunpro MCP enabled and ask: `Check my Bunpro connection.`
 
-For a normal bug, use the repository's bug-report form. Include the client, transport, Node.js version when self-hosting, approximate time, affected tool, and sanitized error message.
+If you have access to the private repository, use its bug-report form and include the client, transport, Node.js version when self-hosting, approximate time, affected tool, and sanitized error message. Public hosted-service users should start with the troubleshooting section on the website; there is currently no public issue tracker.
 
 Never include an Account API Token, token-bearing header, credential screenshot, raw Bunpro response, or personal study data. If a token was exposed, rotate it in Bunpro Settings → API before doing anything else.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bunpro-mcp-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Unofficial stateless, read-only Bunpro MCP with direct Account API Token passthrough",
   "type": "module",
   "private": true,
@@ -10,9 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/yash-278/bunpro-mcp.git"
   },
-  "homepage": "https://github.com/yash-278/bunpro-mcp#readme",
+  "homepage": "https://bunpro.yashkadam.com/",
   "bugs": {
-    "url": "https://github.com/yash-278/bunpro-mcp/issues"
+    "url": "https://bunpro.yashkadam.com/#help"
   },
   "keywords": [
     "bunpro",

--- a/src/homepage.ts
+++ b/src/homepage.ts
@@ -398,7 +398,7 @@ function privacy(): string {
       <div class="privacy-grid">
         <article class="reveal"><span>${icon("check")}</span><h3>What it does</h3><ul><li>Uses an encrypted connection</li><li>Uses your token only for your request</li><li>Returns only the study data needed</li><li>Stops safely if Bunpro cannot be reached</li></ul></article>
         <article class="reveal"><span>${icon("x")}</span><h3>What it does not do</h3><ul><li>Store tokens, sessions, or study history</li><li>Send your token to the language model</li><li>Retry aggressively after Bunpro rate limiting</li><li>Modify reviews, lessons, progress, decks, or settings</li></ul></article>
-        <article class="reveal trust-boundary"><span>${icon("shield")}</span><h3>Who you are trusting</h3><p>As with any hosted service, the service owner and hosting provider could technically see data while a request is being handled. If you are not comfortable with that, run Bunpro MCP on your own computer instead.</p></article>
+        <article class="reveal trust-boundary"><span>${icon("shield")}</span><h3>Who you are trusting</h3><p>As with any hosted service, the service owner and hosting provider could technically see data while a request is being handled. If that trust boundary is not acceptable to you, do not connect the hosted service. Public self-hosting is not available while the source repository remains private.</p></article>
       </div>
     </div>
   </section>`;
@@ -448,7 +448,8 @@ function faq(): string {
     ["Can it change anything in Bunpro?", "No. All eight published tools are read only. The server does not start or submit reviews, change SRS state, add lessons, run crams, edit decks, or modify account settings."],
     ["Does the website receive my token?", "No. This page is static and contains no token field. You paste the token only into your MCP client's protected credential configuration—not into this website or a chat message."],
     ["Does the server store my data?", "No. This service has no account or saved study-history database. It uses your token and Bunpro data only while answering the current request."],
-    ["Is the source code public?", "Not yet. Bunpro's temporary integration details were shared under a restricted disclosure boundary, so the repository remains private unless Bunpro gives written permission for a public source release."],
+    ["Is the source code public?", "No. The hosted MCP is available for Bunpro users, but its source repository remains private because Bunpro shared the temporary integration details under a restricted disclosure boundary. A public source release requires new written permission from Bunpro."],
+    ["Can I clone or self-host it?", "Not as a public user right now. There is no public repository, package, container, or supported local-install path while the source remains private. Use the hosted MCP only if you accept the trust boundary described above."],
     ["Will it work in every ChatGPT account?", "Not necessarily. Developer mode and custom MCP creation availability can depend on your plan, app version, workspace policy, and administrator. Other Streamable HTTP MCP clients may also connect."],
     ["Why are some dates marked as missing?", "Bunpro does not provide the same amount of history for every feature. The answer marks missing information clearly instead of pretending it means zero activity."],
     ["What should I do if I exposed my token?", "Rotate or replace the Account API Token in Bunpro, then update or recreate the protected credential in every MCP client where you configured it."]

--- a/tests/http-service.test.ts
+++ b/tests/http-service.test.ts
@@ -71,7 +71,9 @@ test("the public HTTP service enforces its canonical host and bounded MCP reques
     assert.match(homepage.body, /Leave blank/);
     assert.match(homepage.body, /Check my Bunpro connection/);
     assert.match(homepage.body, /source code public/);
-    assert.match(homepage.body, /repository remains private unless Bunpro gives written permission/);
+    assert.match(homepage.body, /source repository remains private/);
+    assert.match(homepage.body, /Can I clone or self-host it/);
+    assert.match(homepage.body, /Public self-hosting is not available/);
     assert.doesNotMatch(homepage.body, /Available in ChatGPT|Open in ChatGPT|data-concept=/);
     assert.doesNotMatch(homepage.body, /dangerously_authenticate|\/api\/frontend|Token token=/);
 


### PR DESCRIPTION
## Summary
- rewrite the README around the public hosted service
- remove the unusable public clone and self-hosting path while the repository remains private
- clarify the hosted trust boundary and private-source permission gate on the website
- point package metadata at the public product and help pages

## Verification
- TypeScript typecheck passed
- 34/34 tests passed
- production build passed
- repository visibility verified PRIVATE before push