### PR TITLE
Release Bunpro MCP as open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -35,7 +35,7 @@ body:
     id: version
     attributes:
       label: Bunpro MCP commit or version
-      placeholder: 0.3.1 or a commit SHA
+      placeholder: 0.4.0 or a commit SHA
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Bunpro MCP is intentionally read only. Requests that submit reviews, change progress, or modify a Bunpro account are out of scope. Do not include private API details, tokens, raw responses, or personal study data.
+        Bunpro MCP is intentionally read only. Requests that submit reviews, change progress, or modify a Bunpro account are out of scope. Do not include tokens, raw account responses, private correspondence, or personal study data.
   - type: textarea
     id: problem
     attributes:
@@ -25,7 +25,7 @@ body:
     id: evidence
     attributes:
       label: Read-only source evidence
-      description: Which user-visible Bunpro information would support the answer? Do not describe private routes, schemas, or raw responses.
+      description: Which user-visible Bunpro information would support the answer? Do not include real credentials, raw account responses, or personal study data.
     validations:
       required: true
   - type: textarea
@@ -40,5 +40,5 @@ body:
       options:
         - label: This request is read only and does not modify a Bunpro account.
           required: true
-        - label: This issue contains no private API details, credentials, personal data, or raw Bunpro responses.
+        - label: This issue contains no credentials, private correspondence, personal data, or raw Bunpro responses.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Explain the user problem or compatibility issue.
 - [ ] No credentials, cookies, tokens, headers, setup links, personal data, confidential correspondence, or raw Bunpro responses are included.
 - [ ] Tool schemas, annotations, and errors match the implemented behavior.
 - [ ] Privacy, security, support, or setup documentation was updated when behavior changed.
-- [ ] The repository remains private and this change publishes no source artifact or private implementation detail.
+- [ ] This change contains no real credentials, raw account responses, personal study data, or private correspondence.
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,19 @@
-# Repository Safety Policy
+# Repository Safety and Release Policy
 
-## Visibility is a protected constraint
+## Public-source authorization
 
-This repository must remain **PRIVATE**. Bunpro shared the temporary Account API Token workaround under a private-community disclosure boundary. Do not:
+Bunpro authorized this MCP to be released as open source on 2026-08-17. The approval was given by Sean in the private Bunpro community thread titled **API access request for a read-only Bunpro MCP integration**. The private correspondence itself must not be copied into the repository or public announcements.
 
-- change the GitHub repository visibility to public or internal;
-- create a public mirror, fork, package, container, release artifact, documentation site, gist, or code excerpt that exposes the temporary mechanism;
-- publish the private community post or authentication details in a public forum; or
-- add automation that publishes this repository or its artifacts publicly.
+The repository may publicly include the MCP source, Bunpro integration implementation, documented request mechanism, self-hosting instructions, and links to the hosted service.
 
-If the user asks to make the repository or mechanism public, stop and explicitly push back by citing this policy and Bunpro's restriction. Ask for new written permission from Bunpro that specifically authorizes public disclosure before proposing any visibility or publication change. A routine release request, a general statement that open source is desirable, or ownership of the GitHub repository is not sufficient evidence that Bunpro's restriction has changed.
+## Protected constraints
 
-Before and after any GitHub release or repository-settings operation, verify that `yash-278/bunpro-mcp` reports `PRIVATE`. Branches and pull requests for this project must target the same private repository.
+- Keep every Bunpro operation read-only and low-volume.
+- Never commit, log, print, echo, or publish a real Account API Token, credential-bearing header, cookie, password, raw account response, or personal study data.
+- Use only synthetic fixtures and sanitized examples.
+- Do not copy private community posts or private correspondence verbatim into public files.
+- Describe the project as unofficial and experimental; do not imply Bunpro or OpenAI endorsement, an official listing, or a stability guarantee.
+- Preserve the stateless per-caller credential design. A hosted deployment must never use a shared Bunpro token or credential database.
+- Keep `package.json` marked `private` unless package-registry publication receives separate approval.
 
-This constraint does not block private development or operating the hosted MCP as a public community product. Public product documentation may disclose the hosted MCP URL, the MCP client's protected `X-Bunpro-Token` configuration, tool behavior, and user-facing risks. It must not disclose Bunpro's private route names, upstream authorization translation, opt-in query parameter, response schemas, reverse-engineering notes, or repository code. The hosted service must preserve the documented risk disclosure and must never use a deployment-wide Bunpro credential.
+For the visibility cutover, verify that `yash-278/bunpro-mcp` is `PRIVATE` immediately before the change, switch it once, and then verify that it reports `PUBLIC`. After the cutover, verify `PUBLIC` before and after release operations. Pull requests and branches must target that repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,19 @@
 # Changelog
 
-Notable changes to Bunpro MCP are recorded here. The project follows semantic versioning while it remains in private preview.
+Notable changes to Bunpro MCP are recorded here. The project follows semantic versioning.
 
-## 0.3.2 — 2026-08-24
+## 0.4.0 — 2026-08-25
 
-- Reworked the README around the public hosted service and removed an unusable public clone path.
-- Clarified on the website and in privacy guidance that the repository remains private and public self-hosting is not currently available.
-- Pointed package metadata at the public product and help pages rather than private GitHub pages.
-
-## 0.3.1 — 2026-08-24
-
-- Added a public, responsive setup and product homepage at `https://bunpro.yashkadam.com/`.
-- Added repository support guidance, contribution templates, dependency-update configuration, and an explicit future public-source release gate.
+- Released Bunpro MCP as an open-source MIT-licensed project with Bunpro's permission.
+- Added complete hosted, local stdio, Docker, Railway, and generic HTTPS deployment instructions.
+- Updated the public website with source links, a self-hosting section, and open-source FAQ answers.
+- Replaced the private-release guardrail with public-release credential and data-safety constraints.
+- Updated privacy, security, support, contribution, research, and release documentation for public collaboration.
 
 ## 0.3.0 — 2026-08-12
 
 - Added `X-Bunpro-Token` as the preferred hosted credential header, accepting the raw Account API Token without a prefix.
 - Retained `Authorization: Bearer ...` for existing connections and rejected ambiguous dual credentials.
-- Updated hosted setup, privacy, security, and community documentation.
-
-## 0.2.0 — 2026-08-12
-
 - Completed the eight-tool read-only catalog for connection checks, study summaries, schedules, decks, recent activity, progress, and trends.
 - Added bounded schemas, source-coverage semantics, synthetic evaluations, and full transport verification.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,7 +6,7 @@ A secret generated for a Bunpro user on the Settings > API page. It is the only 
 
 ## Frontend API
 
-Bunpro's private, undocumented `/api/frontend/*` interface. Its routes, response shapes, authentication behavior, whitelist, and throttling may change without notice.
+Bunpro's internal, undocumented `/api/frontend/*` interface. Its routes, response shapes, authentication behavior, whitelist, and throttling may change without notice.
 
 ## Direct Token Passthrough
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ npm run check
 
 Run `npm run check` before submitting a pull request.
 
-## Publication boundary
+## Release boundary
 
-The hosted MCP may be used publicly, but the repository must remain private until Bunpro gives written permission that specifically allows public disclosure of the temporary integration mechanism. Do not publish source excerpts, packages, containers, mirrors, or implementation documentation from this repository. See [AGENTS.md](AGENTS.md) and [the source-release gate](docs/public-source-release.md).
+The GitHub source is public under the MIT license. npm and container-registry publication are intentionally disabled unless maintainers approve those channels separately. Do not publish a package or image under this project's name without discussing it first.
+
+Never copy private Bunpro correspondence, real API keys, raw account responses, or personal study data into an issue, pull request, fixture, or documentation example.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-This document explains how Bunpro MCP handles the Bunpro Account API Token and study data. It applies to the private source project and to the hosted service at `https://bunpro.yashkadam.com/mcp`.
+This document explains how Bunpro MCP handles the Bunpro Account API Token and study data. It applies to the open-source server and the hosted service at `https://bunpro.yashkadam.com/mcp`.
 
 ## Local stdio mode
 
@@ -16,7 +16,7 @@ This document explains how Bunpro MCP handles the Bunpro Account API Token and s
 - The application does not create an identity profile, account link, setup session, or database record.
 - The application does not intentionally log or persist token-bearing request headers, the token, Bunpro response bodies, or study history.
 
-The hosted operator and infrastructure provider can technically inspect application memory or traffic where TLS terminates. Stateless passthrough reduces retained data; it does not eliminate the need to trust the hosted service. If that trust boundary is unacceptable, do not use the hosted service. Public local installation and self-hosting are not available while the source repository remains private.
+The hosted operator and infrastructure provider can technically inspect application memory or traffic where TLS terminates. Stateless passthrough reduces retained data; it does not eliminate the need to trust the hosted service. If that trust boundary is unacceptable, run the stdio server locally or self-host the HTTP service.
 
 ## Logs and telemetry
 

--- a/README.md
+++ b/README.md
@@ -1,89 +1,128 @@
 # Bunpro MCP
 
-An unofficial, stateless, read-only Model Context Protocol (MCP) service for asking ChatGPT, Codex, and other MCP clients about your Bunpro studies.
+[![CI](https://github.com/yash-278/bunpro-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/yash-278/bunpro-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-The hosted community service is available at [bunpro.yashkadam.com](https://bunpro.yashkadam.com/). Each person connects with their own Bunpro Account API Token; the service does not use a shared Bunpro account or retain credentials between requests.
+An open-source, stateless, read-only Model Context Protocol (MCP) server for asking ChatGPT, Codex, and other MCP clients about your Bunpro studies.
+
+- **Hosted service:** [bunpro.yashkadam.com](https://bunpro.yashkadam.com/)
+- **Hosted MCP endpoint:** `https://bunpro.yashkadam.com/mcp`
+- **Self-hosting:** [Local, Docker, and Railway guide](docs/self-hosting.md)
+- **Tools:** Eight read-only workflows for activity, reviews, decks, progress, and trends
 
 > [!IMPORTANT]
-> This private project uses Bunpro's experimental Account API Token support for its undocumented Frontend API. It is not affiliated with or endorsed by Bunpro. Routes, schemas, throttling, and whitelist access may change without notice.
+> Bunpro MCP is an unofficial community project. It is not affiliated with or endorsed by Bunpro or OpenAI. It uses experimental, undocumented Bunpro functionality that may change, become unavailable, or be rate-limited without notice.
 
-> [!CAUTION]
-> The repository must remain private. Do not publish, mirror, package, or publicly document the temporary Account API Token mechanism unless Bunpro provides new written permission specifically allowing public disclosure. The agent-enforced policy is recorded in [AGENTS.md](AGENTS.md).
+## What you can ask
 
-## Project status
+- “What did I study yesterday?”
+- “How many reviews are due, and what does this week look like?”
+- “Summarize my Bunpro activity over the last 14 days.”
+- “Which study decks are active?”
+- “How far along am I from JLPT N5 through N1?”
+- “How has my review volume and accuracy changed this month?”
 
-The hosted MCP is live, and the complete read-only tool catalog is implemented.
+Every tool is read-only. Bunpro MCP cannot answer reviews, start lessons or crams, change SRS progress, edit decks, or update account settings.
 
-Available tools:
+## Use the hosted service
 
-- `get_connection_status` verifies that the caller's Bunpro Account API Token can access Bunpro and returns the source timezone.
-- `get_study_day_summary` returns source-backed activity evidence for one exact Bunpro calendar day.
-- `get_study_range_summary` returns every inclusive calendar day in a bounded range using one upstream evidence fetch.
-- `get_review_schedule` returns reviews due now and Bunpro's current daily forecast.
-- `list_study_decks` returns bounded active study-deck goals and completion counts.
-- `get_recent_activity` returns a bounded last-24-hours or latest-attempts view.
-- `get_learning_progress` returns normalized account totals, JLPT progress, review totals, and cram aggregates.
-- `get_activity_trend` returns preserved daily evidence plus explicitly derived range totals and averages.
+### 1. Get your Bunpro token
 
-The prioritized tool catalog and explicit non-goals are tracked in [docs/tool-roadmap.md](docs/tool-roadmap.md).
+Open **Bunpro → Settings → API** and copy your Account API Token. Treat it like a password. Never paste it into a chat, prompt, URL, screenshot, issue, log, or tool argument.
 
-All Bunpro requests are read-only. The server does not submit reviews, start lessons, change progress, or modify account settings.
-
-## Get your Bunpro token
-
-Open **Bunpro → Settings → API** and copy your Account API Token. Treat it like a password. Do not paste it into chat, tool arguments, repository files, screenshots, logs, or support posts.
-
-## Connect the hosted version
-
-The hosted Streamable HTTP endpoint is:
-
-```text
-https://bunpro.yashkadam.com/mcp
-```
+### 2. Add the MCP to ChatGPT
 
 In the ChatGPT/Codex desktop app:
 
 1. Open **Settings → Plugins → MCPs → Add custom MCP**.
-2. Enter `Bunpro MCP`, choose **Streamable HTTP**, and paste the URL above.
-3. Leave **Bearer token env var** blank.
-4. Add a protected custom header named `X-Bunpro-Token` and paste your Bunpro API token as its value.
-5. Save and ask: `Check my Bunpro connection.`
+2. Enter `Bunpro MCP` and choose **Streamable HTTP**.
+3. Set the URL to `https://bunpro.yashkadam.com/mcp`.
+4. Leave **Bearer token env var** blank.
+5. Add a protected custom header named `X-Bunpro-Token`.
+6. Paste the raw Bunpro Account API Token as the header value—without `Bearer` or another prefix.
+7. Save, enable the MCP in a new chat, and ask: `Check my Bunpro connection.`
 
-There is no Auth0 login, Bunpro password form, account-link page, database, or server-side token store. The MCP host attaches the token as a protected request header. The server uses it for that request and does not persist it.
+The hosted deployment has no shared Bunpro credential or account database. Your MCP client attaches your token to each request, and the server does not persist it.
 
-Existing clients configured with `Authorization: Bearer <token>` remain compatible, but new connections should use `X-Bunpro-Token`. Do not configure both headers. Never put the token in the URL or a tool argument.
+Clients already configured with `Authorization: Bearer <token>` remain compatible. Configure exactly one credential method; requests containing both headers are rejected.
 
-## Source and self-hosting status
+## Self-host locally with stdio
 
-The hosted service is available to Bunpro users, but this source repository is currently private. Bunpro shared the temporary integration details under a restricted disclosure boundary, so the project cannot offer public clone, local-install, package, container, or self-hosting instructions yet.
+Requirements:
 
-A public source release requires new written permission from Bunpro that specifically allows disclosure of the integration mechanism. Until that happens, use the hosted endpoint above. If you have been explicitly invited to this private repository, contributor-only local and deployment instructions remain in [docs/self-hosting.md](docs/self-hosting.md).
+- Node.js 20 or newer
+- Git
 
-## Authentication boundary
+```bash
+git clone https://github.com/yash-278/bunpro-mcp.git
+cd bunpro-mcp
+npm ci
+npm run build
+```
 
-Each caller supplies their own token through the MCP client's protected credential configuration. The hosted deployment has no shared Bunpro credential. Tokens remain in request memory only; missing, malformed, or ambiguous credentials fail closed.
+Configure your MCP client to start the compiled server and provide the token through its secret environment configuration:
 
-## Security and limitations
+```json
+{
+  "command": "/absolute/path/to/node",
+  "args": ["/absolute/path/to/bunpro-mcp/dist/index.js"],
+  "env": {
+    "BUNPRO_API_TOKEN": "your Bunpro Account API Token"
+  }
+}
+```
 
-- The model never receives the Account API Token; the MCP host attaches it at the transport layer.
-- The application does not persist tokens, sessions, cookies, study history, or raw Bunpro responses.
-- A hosted operator and infrastructure provider can technically inspect request memory or traffic termination. If that trust boundary is unacceptable, do not use the hosted service; public self-hosting is not available while the source remains private.
-- Use HTTPS for every non-local HTTP deployment.
-- Bunpro has announced stricter throttling and a future route whitelist. Keep calls low-volume and do not retry aggressively.
-- Absence of study data is not automatically evidence of zero activity.
+Use absolute paths. The stdio server writes protocol messages only to stdout and operational messages to stderr.
 
-See [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md) for the full disclosures.
+## Self-host with Docker
 
-## Private-repository development
+```bash
+docker build -t bunpro-mcp .
+docker run --rm -p 8080:8080 \
+  -e TRANSPORT=http \
+  -e PORT=8080 \
+  -e PUBLIC_BASE_URL=http://localhost:8080 \
+  bunpro-mcp
+```
 
-The commands below are for invited repository contributors. They are not a public installation path.
+Your endpoint will be `http://localhost:8080/mcp`. Each caller must still provide their own token through `X-Bunpro-Token`; do not configure a deployment-wide `BUNPRO_API_TOKEN` for HTTP mode.
+
+For an HTTPS deployment on Railway or another host, follow [docs/self-hosting.md](docs/self-hosting.md).
+
+## Available tools
+
+| Tool | What it returns |
+| --- | --- |
+| `get_connection_status` | Authentication status and Bunpro’s source timezone |
+| `get_study_day_summary` | Source-backed activity evidence for one Bunpro calendar day |
+| `get_study_range_summary` | Daily activity evidence for an inclusive range of up to 93 days |
+| `get_review_schedule` | Reviews due now and Bunpro’s current daily forecast |
+| `list_study_decks` | Active study decks, daily goals, and completion counts |
+| `get_recent_activity` | Last-24-hours activity or Bunpro’s latest review attempts |
+| `get_learning_progress` | Account totals, JLPT progress, reviews, and cram aggregates |
+| `get_activity_trend` | Daily evidence with derived totals and averages for a date range |
+
+Missing source data is reported as unavailable, not silently converted to zero.
+
+## Privacy and security
+
+- The application does not persist tokens, cookies, sessions, study history, or raw Bunpro responses.
+- The hosted service uses HTTPS and receives the token only in a protected request header.
+- A hosted operator and infrastructure provider can technically inspect request memory or traffic termination. Run the stdio server locally if you do not accept that trust boundary.
+- Requests are bounded, validated, timed out, and not retried aggressively after Bunpro throttling.
+- Authentication rejection, unavailable routes, and schema drift fail closed with sanitized errors.
+- Rotate an exposed token immediately from **Bunpro → Settings → API**.
+
+Read [SECURITY.md](SECURITY.md) and [PRIVACY.md](PRIVACY.md) before operating a public deployment.
+
+## Development
 
 ```bash
 npm ci
 npm run check
 ```
 
-The opt-in live connection test uses your own Account API Token and performs read-only requests:
+Optional live tests use your own Bunpro token and perform read-only, deliberately paced requests:
 
 ```bash
 BUNPRO_API_TOKEN="your token" npm run live:test:auth
@@ -92,16 +131,14 @@ BUNPRO_API_TOKEN="your token" npm run live:test:tools
 BUNPRO_API_TOKEN="your token" BUNPRO_MCP_URL="https://your-host.example/mcp" npm run live:test:tools
 ```
 
-The first command tests stdio. The second tests the HTTP `X-Bunpro-Token` passthrough. The third makes one deliberately paced pass through every published tool in process; adding `BUNPRO_MCP_URL` runs the same sweep against a deployed Streamable HTTP endpoint. All use the real Bunpro API, and the tool sweep prints only tool names and success states. Do not attach raw Bunpro responses or secrets to issues.
+The live scripts print only bounded status information. Never attach raw Bunpro responses or credentials to an issue.
 
 ## Contributing and support
 
-Bug reports, compatibility reports, and focused pull requests are welcome from people who already have access to the private project. Read [CONTRIBUTING.md](CONTRIBUTING.md), [SUPPORT.md](SUPPORT.md), and the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+Issues and focused pull requests are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), [SUPPORT.md](SUPPORT.md), and the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-If you use only the hosted service, do not include your Bunpro token or raw study data in a support message. The public website includes setup help and a token-safe health check.
-
-Release history is recorded in [CHANGELOG.md](CHANGELOG.md). The repository's future public-source release remains gated by the Bunpro permission requirements in [docs/public-source-release.md](docs/public-source-release.md).
+Security vulnerabilities should be reported privately through GitHub as described in [SECURITY.md](SECURITY.md).
 
 ## License
 
-[MIT](LICENSE). Bunpro names and trademarks belong to their respective owner.
+[MIT](LICENSE). Bunpro names, content, and trademarks belong to their respective owners.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported version
 
-Security fixes are applied to the latest commit on `main`. There is no stable release branch during the private preview.
+Security fixes are applied to the latest commit on `main`. There is no separate stable release branch yet.
 
 ## Report a vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ Before reporting a problem:
 3. Confirm the protected header name is exactly `X-Bunpro-Token` and its value contains only the current Bunpro Account API Token.
 4. Start a new chat with Bunpro MCP enabled and ask: `Check my Bunpro connection.`
 
-If you have access to the private repository, use its bug-report form and include the client, transport, Node.js version when self-hosting, approximate time, affected tool, and sanitized error message. Public hosted-service users should start with the troubleshooting section on the website; there is currently no public issue tracker.
+For a normal bug, use the repository's public bug-report form. Include the client, transport, Node.js version when self-hosting, approximate time, affected tool, and sanitized error message.
 
 Never include an Account API Token, token-bearing header, credential screenshot, raw Bunpro response, or personal study data. If a token was exposed, rotate it in Bunpro Settings → API before doing anything else.
 

--- a/docs/adr/0004-direct-account-token-passthrough.md
+++ b/docs/adr/0004-direct-account-token-passthrough.md
@@ -6,7 +6,7 @@ status: accepted
 
 ## Context
 
-Bunpro privately introduced an experimental opt-in parameter that lets its Account API Token authenticate Frontend API requests. Authorized, low-volume testing confirmed that the four read-only routes required by Atlas return JSON when the Account API Token and opt-in parameter are supplied together.
+Bunpro introduced an experimental opt-in parameter that lets its Account API Token authenticate Frontend API requests. Authorized, low-volume testing confirmed that the four read-only routes required by Atlas return JSON when the Account API Token and opt-in parameter are supplied together.
 
 The previous hosted design used Auth0 identity, a setup page, encrypted Bunpro username/password storage, PostgreSQL, browser cookies, and frontend-token refresh. Those layers are unnecessary when every caller can supply their own Account API Token through the MCP host's protected-header configuration.
 

--- a/docs/community-post.md
+++ b/docs/community-post.md
@@ -46,6 +46,12 @@ Other MCP-compatible apps can use the same URL and protected header, although th
 
 Please put the token only in the protected connection field. Never paste it into a chat message, screenshot, URL, support post, or tool argument.
 
+## Open source and self-hosting
+
+The project is open source under the MIT license: [github.com/yash-278/bunpro-mcp](https://github.com/yash-278/bunpro-mcp).
+
+You can use the hosted endpoint above, run the MCP locally over stdio, or deploy your own stateless HTTP instance with Docker. The repository includes instructions for local setup, Railway, and other HTTPS hosts. A self-hosted HTTP service still requires each caller to provide their own Bunpro Account API Token; it should never use one shared Bunpro credential.
+
 ## What it can show you
 
 The current version can read:
@@ -70,6 +76,8 @@ It relies on experimental Bunpro functionality, so Bunpro changes, rate limits, 
 Your MCP app sends your Bunpro token to the server over HTTPS when it requests data. The connector does not have a token database, create user accounts, or save your study history. Its application logs are designed not to include tokens, protected token headers, or returned study data.
 
 The server is hosted on Railway. As with any hosted service, I and the hosting provider could technically inspect data while a request is being handled. Please connect only if you are comfortable trusting both of us. If you are not, do not use the hosted version.
+
+Because the source is public, you can also inspect the implementation and run it locally to reduce that trust boundary.
 
 “Read-only” describes what this connector can do, not how sensitive the token is. The token can reveal private Bunpro account and study information, so continue to treat it like a password.
 

--- a/docs/public-source-release.md
+++ b/docs/public-source-release.md
@@ -1,41 +1,29 @@
-# Public-source release gate
+# Public-source release record
 
-The hosted Bunpro MCP is a public community product. The source repository is not currently authorized for public disclosure and must remain private.
+## Authorization
 
-## Blocking approval
+Bunpro authorized an open-source release of Bunpro MCP.
 
-Before changing repository visibility or publishing any source artifact, obtain new written permission from Bunpro that explicitly covers all intended channels:
+- **Date:** 2026-08-17
+- **Approver:** Sean, Bunpro
+- **Authorized scope:** Public GitHub source for the read-only MCP, including the integration implementation and self-hosting documentation
+- **Durable private reference:** Bunpro community thread, **API access request for a read-only Bunpro MCP integration**
 
-- a public GitHub repository containing the temporary integration code;
-- public disclosure of the request mechanism, route names, and authentication translation present in source and technical documentation;
-- any package registry, container registry, mirror, generated documentation site, or downloadable release artifact; and
-- any public forum announcement that links to or explains the source implementation.
+The confidential conversation and screenshots are not committed. Public materials should summarize the permission only as needed and must continue to protect user API keys.
 
-Store the approval privately. Record only its date, approver, authorized scope, and durable private reference in the release issue; do not commit confidential correspondence.
+## Release checklist
 
-General encouragement, permission to operate the hosted service, ownership of the repository, or permission to include code in a repository without permission to publicly disclose the mechanism does not satisfy this gate.
+- [x] Written Bunpro approval recorded without publishing private correspondence.
+- [x] MIT license, contribution policy, security policy, privacy disclosure, support guide, and code of conduct present.
+- [x] README covers hosted use, local stdio, Docker, remote hosting, tools, risks, and token handling.
+- [x] Public website links the source and explains self-hosting.
+- [x] Current tree and complete Git history scanned for committed credentials.
+- [x] Obsolete private-source warnings removed from public documentation.
+- [x] CI covers supported Node.js versions.
+- [ ] Release pull request passes CI and review.
+- [ ] Repository visibility reports `PUBLIC` after merge.
+- [ ] GitHub security settings and branch protection are verified.
+- [ ] Railway deploys the public-release commit successfully.
+- [ ] Public website, health check, and MCP authentication boundary pass final smoke checks.
 
-## Preparation complete while private
-
-- [x] MIT license and copyright notice.
-- [x] README with capabilities, local and hosted setup, limitations, and trust boundary.
-- [x] Security, privacy, support, contribution, and conduct policies.
-- [x] Bug, feature, and pull-request templates that prohibit credential disclosure.
-- [x] CI on supported Node.js versions and weekly dependency update configuration.
-- [x] Stateless, read-only tools with strict schemas, bounded responses, timeouts, and sanitized failures.
-- [x] Docker and Railway deployment configuration with no database or deployment-wide Bunpro credential.
-- [x] Public hosted service and health check.
-- [x] Repository-level guardrail that blocks accidental visibility and artifact publication.
-
-## Actions permitted only after approval
-
-1. Review the written permission against each intended publication channel.
-2. Decide whether private research notes and superseded authentication ADRs are within scope; remove them from the public history if they are not.
-3. Scan the complete Git history for credentials, private correspondence, raw account data, and out-of-scope implementation details.
-4. Re-run `npm ci`, `npm run check`, dependency auditing, the synthetic evaluation, and a low-volume hosted smoke test.
-5. Verify branch protection, private vulnerability reporting, issue settings, and least-privilege workflow permissions.
-6. Keep `package.json` marked `private` unless package-registry publication is separately approved.
-7. Change visibility only after a final maintainer review, then verify the repository and all artifacts expose only the authorized scope.
-8. Re-check the Railway deployment and public disclosures after the visibility change.
-
-If approval is narrower than this plan, narrow the release to match it. Do not infer permission for another channel.
+Package-registry or container-registry publication is not part of this release. `package.json` remains marked `private` to prevent accidental npm publication.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,45 +1,36 @@
-# Hosted community release checklist
+# Open-source community release checklist
 
-The hosted MCP may be announced publicly. The repository and Bunpro-specific request mechanism must remain private.
+## Authorization and repository
 
-## Repository boundary
-
-- [x] Repository policy explicitly requires GitHub visibility to remain private.
-- [x] Public documentation excludes private routes, authentication translation, opt-in parameters, schemas, reverse-engineering notes, and source code.
-- [x] README documents the implemented read-only catalog and maintainer setup.
-- [x] Privacy, security, contribution, and conduct policies are present.
-- [x] Re-scan the current tree and Git history for credentials immediately before merge.
-- [x] Confirm `yash-278/bunpro-mcp` reports `PRIVATE` before and after the release merge.
+- [x] Bunpro open-source approval is recorded in [the release record](public-source-release.md).
+- [x] Private correspondence and screenshots are excluded from the repository.
+- [x] Current source and full Git history were scanned for credentials and personal data.
+- [x] README documents hosted use, local stdio, Docker, and remote HTTPS deployment.
+- [x] Security, privacy, support, contribution, conduct, and license files are present.
+- [ ] Release pull request passes all required checks.
+- [ ] Repository visibility reports `PUBLIC` after merge.
+- [ ] Branch protection, vulnerability reporting, secret scanning, and workflow permissions are verified.
 
 ## Hosted service
 
-- [x] Railway deploys automatically from the private repository's `main` branch.
-- [x] Set `PUBLIC_BASE_URL=https://bunpro.yashkadam.com`.
-- [x] Remove obsolete Auth0, database, encryption-key, setup-token, username, password, and deployment-wide Bunpro token variables. Verified on Railway by variable name on 2026-08-24; only platform metadata, `NODE_ENV`, `PUBLIC_BASE_URL`, and `TRANSPORT` remain.
-- [x] Confirm `GET /healthz` returns HTTP 200 on the canonical domain.
-- [x] Confirm the generated Railway domain is not an alternate public entry point after the canonical domain works.
-- [x] Confirm a missing, malformed, or ambiguous token header receives HTTP 401 without leaking request data.
-- [x] Run one low-volume live smoke pass across every published tool with a valid caller token.
-- [x] Confirm one invalid token produces a sanitized authentication error.
-- [x] Review edge rate limits and abuse controls without logging token-bearing headers or response bodies. The shared upstream gate permits four active calls and sixteen queued calls, request and response sizes are bounded, calls time out, and rate-limited requests are not retried automatically. No caller identity or token-derived rate-limit record is stored.
+- [x] Railway deploys automatically from `main` using the included Dockerfile.
+- [x] The production service has no Auth0, database, encryption-key, setup-token, username, password, or deployment-wide Bunpro token variables.
+- [x] Every caller provides their own token through a protected request header.
+- [x] Host validation, body limits, response limits, timeouts, and bounded upstream concurrency are enabled.
+- [x] Bunpro throttling is not retried automatically.
+- [ ] Railway deploys the v0.4.0 public-release commit successfully.
+- [ ] `GET /healthz` returns HTTP 200 on the canonical domain.
+- [ ] Missing and ambiguous token requests return HTTP 401 without leaking request data.
+- [ ] A low-volume tool smoke passes with a valid caller-owned token.
 
-## Product behavior
+## Product and documentation
 
-- [x] All published tools are read-only, stateless, bounded, and annotated as non-destructive.
-- [x] Authentication, throttling, route removal, and schema drift fail closed.
-- [x] Sparse historical absence is not silently represented as zero study.
-- [x] The server stores no caller credential, session, cookie, account profile, watermark, or study history.
-- [x] Complete the final automated verification suite and private pull-request review.
+- [x] All eight tools are read-only, stateless, bounded, and annotated as non-destructive.
+- [x] Authentication, throttling, unavailable routes, malformed responses, and schema drift fail closed.
+- [x] Sparse historical absence is not silently represented as zero.
+- [x] Public website links the GitHub repository and self-hosting guide.
+- [x] FAQ states that the project is open source and can run locally or remotely.
+- [x] Public copy explains unofficial status, experimental access, hosted-operator trust, and token rotation.
+- [ ] Production website shows the open-source release content.
 
-## Public announcement
-
-- [x] The draft explains setup using only the hosted URL and protected `X-Bunpro-Token` header.
-- [x] The draft explains all eight capabilities in user-facing language.
-- [x] The draft discloses the unofficial/experimental status, partial failures, throttling, hosted-operator trust boundary, best-effort availability, and token rotation.
-- [x] The draft does not link to or describe how to reproduce the private implementation.
-- [x] Reader-test [the public announcement draft](community-post.md) for clarity and accidental disclosure.
-- [ ] Publish only after every hosted-service gate above is complete.
-
-The hosted-service gates are complete as of 2026-08-24. Publishing this community announcement does not authorize changing the repository visibility or publishing the source. See [the separate public-source release gate](public-source-release.md).
-
-Atlas integration is intentionally out of scope for this release. Do not edit the Atlas vault or infer an Atlas watermark from MCP output during release work.
+Atlas integration remains out of scope for this release.

--- a/docs/research/bunpro-account-token-api.md
+++ b/docs/research/bunpro-account-token-api.md
@@ -3,7 +3,7 @@
 Research date: 2026-08-12
 
 > [!CAUTION]
-> This note records a temporary Bunpro authentication workaround shared in a private Bunpro community group. Keep this repository private and do not reproduce the mechanism in public forums. Bunpro describes the mechanism as experimental, undocumented, subject to stricter throttling and a future route whitelist, and changeable without notice. Any invited-user documentation must disclose those risks.
+> This note records experimental, undocumented Bunpro behavior that is subject to stricter throttling, a future route whitelist, and change without notice. Implementations must remain read-only, low-volume, and careful with user API keys.
 
 ## Question
 
@@ -57,7 +57,7 @@ Only the literal `true` parameter value was tested. Other values must not be tre
 
 No `Retry-After`, standard `RateLimit-*`, or `X-RateLimit-*` headers appeared on the eight naturally observed responses. No route-whitelist metadata was exposed in response headers.
 
-This is absence of an observed signal, not evidence that throttling is absent. The private Bunpro update says stricter throttling was added on 2026-08-12 and that a whitelisted-route system is planned. The research deliberately did not induce HTTP 429, discover unrelated routes, parallelize calls, or approach any limit. Exact quotas, reset behavior, 429 response semantics, and future whitelist membership remain unknown.
+This is absence of an observed signal, not evidence that throttling is absent. Bunpro guidance says stricter throttling was added on 2026-08-12 and that a whitelisted-route system is planned. The research deliberately did not induce HTTP 429, discover unrelated routes, parallelize calls, or approach any limit. Exact quotas, reset behavior, 429 response semantics, and future whitelist membership remain unknown.
 
 ## Implementation consequences
 
@@ -74,7 +74,7 @@ This is absence of an observed signal, not evidence that throttling is absent. T
 
 Primary sources:
 
-- Bunpro private community group update supplied by the project owner, last updated 2026-08-12. It defines the temporary opt-in parameter, identifies the Settings > API Account API Token, permits inclusion in public repositories while prohibiting public-forum disclosure, warns of endpoint instability, requests low-impact use and user risk disclosure, and announces stricter throttling plus a planned route whitelist.
+- Bunpro community guidance supplied to the project owner, last updated 2026-08-12. It defines the temporary opt-in parameter, identifies the Settings > API Account API Token, warns of endpoint instability, requests low-impact use and user risk disclosure, and announces stricter throttling plus a planned route whitelist.
 - The repository's current Frontend API request implementation in [`src/bunpro/client.ts`](../../src/bunpro/client.ts), which established the existing `Token token=...` header syntax to test with the Account API Token.
 - The previously verified route inventory and response semantics in [Bunpro frontend authentication and study API evidence](./bunpro-frontend-api.md).
 - Eight authorized live HTTP GET requests on 2026-08-12 using the user's `BUNPRO_API_TOKEN`: four required-route successes and four bounded authentication-contract checks. The temporary probe held the token and parsed payloads only in process memory and was deleted immediately afterward.

--- a/docs/research/bunpro-api-evidence.md
+++ b/docs/research/bunpro-api-evidence.md
@@ -2,7 +2,7 @@
 
 Research date: 2026-08-10
 
-> Authentication-boundary update (2026-08-12): Bunpro's private community has since supplied a temporary Account API Token authentication mechanism for Frontend API routes. Authorized testing confirmed the Atlas-required contract in [Bunpro Account API Token request contract](./bunpro-account-token-api.md). The evidence gaps and intermediate browser-login choice recorded below are historical and superseded.
+> Authentication-boundary update (2026-08-12): Bunpro supplied a temporary Account API Token authentication mechanism for Frontend API routes. Authorized testing confirmed the Atlas-required contract in [Bunpro Account API Token request contract](./bunpro-account-token-api.md). The evidence gaps and intermediate browser-login choice recorded below are historical and superseded.
 
 ## Question
 
@@ -36,7 +36,7 @@ Current Bunpro behavior confirms at least one frontend route still exists: an un
 
 Bunpro staff also pointed a community developer to the site's Search API and suggested inspecting the request payload from the current UI. That is evidence of an internal surface in January 2026, but it is a content/search surface and does not establish date-bounded personal study history or Account API Token support. [Permission to reverse engineer the Bunpro API — Sean, 26 January 2026](https://community.bunpro.jp/t/permission-to-reverse-engineer-the-bunpro-api/164173/7)
 
-**Historical decision consequence:** the project initially forbade the Frontend Session Token. That boundary was superseded on 2026-08-11 for the private phase after Account-token testing failed; see ADR 0001 and the authenticated frontend research note.
+**Historical decision consequence:** the project initially forbade the Frontend Session Token. That boundary was superseded during early research after Account-token testing failed; see ADR 0001 and the authenticated frontend research note.
 
 ### Bunpro expressly permits reverse-engineering and public documentation, with no stability promise
 

--- a/docs/research/bunpro-frontend-api.md
+++ b/docs/research/bunpro-frontend-api.md
@@ -66,7 +66,7 @@ A missing key in a sparse heatmap has not yet been proven equivalent to zero. Un
 
 ## Compatibility and security constraints
 
-- These are private frontend contracts, not a supported public API. Bunpro may change them without notice.
+- These are internal frontend contracts, not a supported public API. Bunpro may change them without notice.
 - Authentication must fail closed. The MCP must never return, print, log, or persist Account API Tokens. Cookies, authenticity values, and frontend-cookie tokens are no longer part of the target design.
 - All Bunpro calls remain read-only and low volume.
 - Local mode reads the Account API Token from `BUNPRO_API_TOKEN`; hosted mode receives it per request from the MCP host's protected `X-Bunpro-Token` configuration and does not persist it.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,60 +1,138 @@
-# Self-hosting the Streamable HTTP server
+# Self-hosting Bunpro MCP
 
-The remote deployment is a stateless Streamable HTTP server. It does not need Auth0, an OAuth authorization server, PostgreSQL, an encryption key, a setup page, or a deployment-wide Bunpro credential.
+Bunpro MCP supports two stateless transports:
 
-Each MCP caller supplies their own Bunpro Account API Token in the `X-Bunpro-Token` request header. The application uses the token for that request and does not persist it.
+- **stdio** for a single local MCP client;
+- **Streamable HTTP** for a remote HTTPS service used by one or more clients.
 
-## Requirements
+The server needs no Auth0 tenant, OAuth provider, PostgreSQL database, encryption key, setup page, Bunpro username, or Bunpro password.
 
-- Node.js 20 or newer, or the included Dockerfile
-- An HTTPS deployment target such as Railway
-- A public hostname
+## Choose a deployment
 
-## Environment
+| Option | Best for | Token location |
+| --- | --- | --- |
+| Local stdio | One desktop client and the smallest trust boundary | `BUNPRO_API_TOKEN` in the MCP client's secret environment configuration |
+| Local Docker HTTP | Testing the remote transport locally | Each caller sends `X-Bunpro-Token` |
+| Railway or another HTTPS host | Multiple users or devices | Each caller sends `X-Bunpro-Token` |
 
-```dotenv
-TRANSPORT=http
-PUBLIC_BASE_URL=https://mcp.example.com
+Never configure a shared `BUNPRO_API_TOKEN` on an HTTP deployment. Every HTTP caller must supply their own credential.
+
+## Local stdio
+
+Requirements:
+
+- Node.js 20 or newer
+- Git
+
+```bash
+git clone https://github.com/yash-278/bunpro-mcp.git
+cd bunpro-mcp
+npm ci
+npm run build
 ```
 
-Railway sets `PORT` and `RAILWAY_PUBLIC_DOMAIN`; when the latter is present, `PUBLIC_BASE_URL` may be omitted. Do not configure `BUNPRO_API_TOKEN` on the HTTP service. That variable is only for local stdio mode.
+Configure the MCP client with absolute paths:
 
-No database service is required.
+```json
+{
+  "command": "/absolute/path/to/node",
+  "args": ["/absolute/path/to/bunpro-mcp/dist/index.js"],
+  "env": {
+    "BUNPRO_API_TOKEN": "your Bunpro Account API Token"
+  }
+}
+```
 
-## Railway deployment
+The token remains in the local process memory while the server runs. Bunpro MCP does not write it to disk, although the MCP client may persist its own secret configuration.
 
-1. Deploy this private repository using the included Dockerfile.
-2. Set `TRANSPORT=http`.
-3. Set `PUBLIC_BASE_URL` to the canonical HTTPS domain users will configure.
-4. Remove obsolete Auth0, database, setup-token, encryption-key, Bunpro username, and Bunpro password variables from the service.
-5. Confirm `GET /healthz` returns HTTP 200.
+## Local Docker HTTP
 
-## Configure a caller
+Build and start the included image:
 
-Use:
+```bash
+docker build -t bunpro-mcp .
+docker run --rm -p 8080:8080 \
+  -e TRANSPORT=http \
+  -e PORT=8080 \
+  -e PUBLIC_BASE_URL=http://localhost:8080 \
+  bunpro-mcp
+```
+
+The local endpoint is:
 
 ```text
-https://mcp.example.com/mcp
+http://localhost:8080/mcp
 ```
 
-In ChatGPT/Codex, leave **Bearer token env var** blank and add a protected custom header named `X-Bunpro-Token`. Its value is the raw Bunpro Account API Token, with no prefix.
+Configure the MCP client with a protected `X-Bunpro-Token` header containing the raw Account API Token. Leave Bearer authentication blank.
 
-The backwards-compatible `Authorization: Bearer <token>` form is still accepted for existing connections. Configure exactly one credential header, and never place the token in the URL or tool arguments.
+## Railway
 
-## Smoke checks
+1. Fork or clone `https://github.com/yash-278/bunpro-mcp`.
+2. Create a Railway service from the repository.
+3. Railway will build the included `Dockerfile` and use `railway.json` for the health check.
+4. Set these variables:
 
-Without a token header, `/mcp` should return HTTP 401 without echoing request data. With a valid token configured in an MCP client, `get_connection_status` should report:
+   ```dotenv
+   TRANSPORT=http
+   PUBLIC_BASE_URL=https://your-domain.example
+   ```
 
-- `authentication_method: account_api_token`
-- `token_source: request_header`
-- `token_persisted_by_server: false`
-- `api_authenticated: true`
-- `stateless: true`
+   Railway supplies `PORT`. If you use Railway's generated domain, `RAILWAY_PUBLIC_DOMAIN` can supply the canonical hostname and `PUBLIC_BASE_URL` may be omitted.
 
-The health endpoint intentionally requires no token and reveals no account data.
+5. Do **not** add `BUNPRO_API_TOKEN`, Bunpro username/password values, Auth0 variables, database variables, or encryption keys.
+6. Add an HTTPS public domain and confirm `GET /healthz` returns `{"status":"ok"}`.
+7. Configure each MCP client with `https://your-domain.example/mcp` and its own protected `X-Bunpro-Token` value.
 
-## Trust boundary
+## Another HTTPS host
 
-The application does not persist tokens, but the hosting operator and platform can technically inspect request memory or traffic termination. Users who do not accept that boundary should run the stdio transport locally.
+The same container works on platforms that can:
 
-Keep use low-volume. Bunpro's temporary mechanism has stricter throttling, an evolving route whitelist, and no compatibility guarantee.
+- build the included Dockerfile;
+- expose the configured `PORT`;
+- provide HTTPS termination; and
+- set `TRANSPORT=http` plus a canonical `PUBLIC_BASE_URL`.
+
+Non-local `PUBLIC_BASE_URL` values must use HTTPS. Host-header validation rejects alternate hostnames.
+
+## Credential contract
+
+Preferred HTTP configuration:
+
+```text
+X-Bunpro-Token: <raw Bunpro Account API Token>
+```
+
+`Authorization: Bearer <token>` remains available for clients that cannot set a custom protected header. Configure exactly one method. Requests with missing, malformed, oversized, or ambiguous credentials receive HTTP 401.
+
+Never place a token in:
+
+- a URL or query string;
+- an MCP tool argument;
+- a repository or `.env` file committed to Git;
+- a log, screenshot, issue, or support message; or
+- a shared deployment variable for HTTP mode.
+
+## Verification
+
+Without a token, `/mcp` should return HTTP 401 without echoing request data. `/healthz` intentionally requires no credential and exposes no account data.
+
+With a valid token configured in an MCP client, call `get_connection_status`. A successful response reports that authentication passed, the transport is stateless, and the server did not persist the token.
+
+For maintainers, the repository includes deliberately paced live smoke scripts:
+
+```bash
+BUNPRO_API_TOKEN="your token" npm run live:test:auth
+BUNPRO_API_TOKEN="your token" npm run live:test:http
+BUNPRO_API_TOKEN="your token" BUNPRO_MCP_URL="https://your-domain.example/mcp" npm run live:test:tools
+```
+
+## Operational limits
+
+- Keep traffic low-volume and do not retry aggressively.
+- Bunpro may throttle requests or change its route whitelist without notice.
+- The server bounds request sizes, response sizes, concurrent upstream work, and timeouts.
+- Authentication rejection, throttling, unavailable routes, malformed responses, and schema drift fail closed.
+- The service stores no token, account profile, study history, cookie, session, or watermark.
+
+Anyone operating a hosted instance can technically inspect process memory or traffic where TLS terminates. Users who do not accept that trust boundary should run the stdio transport locally.

--- a/docs/tool-roadmap.md
+++ b/docs/tool-roadmap.md
@@ -1,6 +1,6 @@
 # Bunpro MCP tool roadmap
 
-Status: implemented catalog for the private, read-only MCP
+Status: implemented catalog for the open-source, read-only MCP
 
 This roadmap translates the confirmed Bunpro Frontend API surfaces into agent-facing workflows. It is intentionally not a one-tool-per-endpoint wrapper. Each tool should answer a recognizable user question, return structured content, disclose source coverage, and stay within a conservative Bunpro request budget.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bunpro-mcp-server",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunpro-mcp-server",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Unofficial stateless, read-only Bunpro MCP with direct Account API Token passthrough",
   "type": "module",
   "private": true,
@@ -12,7 +12,7 @@
   },
   "homepage": "https://bunpro.yashkadam.com/",
   "bugs": {
-    "url": "https://bunpro.yashkadam.com/#help"
+    "url": "https://github.com/yash-278/bunpro-mcp/issues"
   },
   "keywords": [
     "bunpro",

--- a/src/homepage.ts
+++ b/src/homepage.ts
@@ -2,6 +2,8 @@ const MCP_ENDPOINT = "https://bunpro.yashkadam.com/mcp";
 const CHATGPT_PLUGINS_URL = "https://chatgpt.com/plugins";
 const OPENAI_MCP_GUIDE_URL = "https://developers.openai.com/plugins/deploy/connect-chatgpt";
 const BUNPRO_TOKEN_HEADER = "X-Bunpro-Token";
+const SOURCE_REPOSITORY_URL = "https://github.com/yash-278/bunpro-mcp";
+const SELF_HOSTING_GUIDE_URL = `${SOURCE_REPOSITORY_URL}/blob/main/docs/self-hosting.md`;
 
 export const HOMEPAGE_ROBOTS = `User-agent: *
 Allow: /
@@ -155,6 +157,7 @@ export function renderHomepage(_url: URL): string {
     ${useCases()}
     ${explanation()}
     ${setupGuide()}
+    ${openSource()}
     ${toolCatalog()}
     ${promptGallery()}
     ${privacy()}
@@ -180,6 +183,7 @@ function header(): string {
       <nav class="desktop-nav" aria-label="Primary navigation">
         <a href="#possibilities">What it does</a>
         <a href="#setup">Set up</a>
+        <a href="#self-host">Self-host</a>
         <a href="#tools">Tools</a>
         <a href="#privacy">Privacy</a>
         <a href="#help">Help</a>
@@ -190,7 +194,7 @@ function header(): string {
       </button>
     </div>
     <nav class="mobile-nav" id="mobile-menu" aria-label="Mobile navigation" hidden>
-      <a href="#possibilities">What it does</a><a href="#setup">Set up</a><a href="#tools">Tools</a><a href="#privacy">Privacy</a><a href="#help">Help</a>
+      <a href="#possibilities">What it does</a><a href="#setup">Set up</a><a href="#self-host">Self-host</a><a href="#tools">Tools</a><a href="#privacy">Privacy</a><a href="#help">Help</a>
       <a class="button button-primary" href="#setup">Connect to ChatGPT ${icon("arrow")}</a>
     </nav>
   </header>`;
@@ -347,6 +351,22 @@ function copyField(label: string, value: string, nested = false): string {
   return `<div class="form-row${nested ? " nested" : ""}"><label>${label}</label><div class="copy-field"><code>${value}</code><button type="button" data-copy="${value}" aria-label="Copy ${label}">${icon("copy")}</button></div></div>`;
 }
 
+function openSource(): string {
+  return `<section class="section open-source" id="self-host">
+    <div class="shell">
+      <div class="section-heading reveal">
+        <div><span class="kicker">Open source</span><h2>Use the hosted service—<br><em>or run your own.</em></h2></div>
+        <p>Bunpro MCP is available under the MIT license. You can inspect the implementation, run it locally over stdio, or deploy your own stateless Streamable HTTP server.</p>
+      </div>
+      <div class="source-grid">
+        <article class="source-card reveal"><span>${icon("terminal")}</span><small>LOCAL</small><h3>Run with stdio</h3><p>Clone the repository, build it with Node.js 20 or newer, and keep the Account API Token in your MCP client's secret environment configuration.</p></article>
+        <article class="source-card reveal"><span>${icon("layers")}</span><small>REMOTE</small><h3>Deploy with Docker</h3><p>Use the included Dockerfile on Railway or another HTTPS host. Every caller supplies their own token; the deployment needs no database or shared Bunpro credential.</p></article>
+        <article class="source-card source-actions reveal"><span>${icon("shield")}</span><small>TRANSPARENT</small><h3>Review before you trust</h3><p>Read the source, privacy boundary, and operational limits before connecting an account or operating a public instance.</p><div><a class="button button-primary" href="${SOURCE_REPOSITORY_URL}" target="_blank" rel="noreferrer">View source ${icon("external")}</a><a class="inline-link" href="${SELF_HOSTING_GUIDE_URL}" target="_blank" rel="noreferrer">Self-hosting guide ${icon("external")}</a></div></article>
+      </div>
+    </div>
+  </section>`;
+}
+
 function toolCatalog(): string {
   return `<section class="section tools" id="tools">
     <div class="shell">
@@ -398,7 +418,7 @@ function privacy(): string {
       <div class="privacy-grid">
         <article class="reveal"><span>${icon("check")}</span><h3>What it does</h3><ul><li>Uses an encrypted connection</li><li>Uses your token only for your request</li><li>Returns only the study data needed</li><li>Stops safely if Bunpro cannot be reached</li></ul></article>
         <article class="reveal"><span>${icon("x")}</span><h3>What it does not do</h3><ul><li>Store tokens, sessions, or study history</li><li>Send your token to the language model</li><li>Retry aggressively after Bunpro rate limiting</li><li>Modify reviews, lessons, progress, decks, or settings</li></ul></article>
-        <article class="reveal trust-boundary"><span>${icon("shield")}</span><h3>Who you are trusting</h3><p>As with any hosted service, the service owner and hosting provider could technically see data while a request is being handled. If that trust boundary is not acceptable to you, do not connect the hosted service. Public self-hosting is not available while the source repository remains private.</p></article>
+        <article class="reveal trust-boundary"><span>${icon("shield")}</span><h3>Who you are trusting</h3><p>As with any hosted service, the service owner and hosting provider could technically see data while a request is being handled. If that trust boundary is not acceptable to you, run Bunpro MCP locally or deploy your own instance from the open-source repository.</p></article>
       </div>
     </div>
   </section>`;
@@ -448,8 +468,8 @@ function faq(): string {
     ["Can it change anything in Bunpro?", "No. All eight published tools are read only. The server does not start or submit reviews, change SRS state, add lessons, run crams, edit decks, or modify account settings."],
     ["Does the website receive my token?", "No. This page is static and contains no token field. You paste the token only into your MCP client's protected credential configuration—not into this website or a chat message."],
     ["Does the server store my data?", "No. This service has no account or saved study-history database. It uses your token and Bunpro data only while answering the current request."],
-    ["Is the source code public?", "No. The hosted MCP is available for Bunpro users, but its source repository remains private because Bunpro shared the temporary integration details under a restricted disclosure boundary. A public source release requires new written permission from Bunpro."],
-    ["Can I clone or self-host it?", "Not as a public user right now. There is no public repository, package, container, or supported local-install path while the source remains private. Use the hosted MCP only if you accept the trust boundary described above."],
+    ["Is the source code public?", `Yes. Bunpro MCP is open source under the MIT license. You can inspect, fork, and contribute to it on <a class="inline-link" href="${SOURCE_REPOSITORY_URL}" target="_blank" rel="noreferrer">GitHub ${icon("external")}</a>.`],
+    ["Can I run it myself?", `Yes. Run it locally over stdio or deploy the included Docker image as a stateless Streamable HTTP service. The <a class="inline-link" href="${SELF_HOSTING_GUIDE_URL}" target="_blank" rel="noreferrer">self-hosting guide ${icon("external")}</a> covers local, Docker, Railway, and other HTTPS hosts.`],
     ["Will it work in every ChatGPT account?", "Not necessarily. Developer mode and custom MCP creation availability can depend on your plan, app version, workspace policy, and administrator. Other Streamable HTTP MCP clients may also connect."],
     ["Why are some dates marked as missing?", "Bunpro does not provide the same amount of history for every feature. The answer marks missing information clearly instead of pretending it means zero activity."],
     ["What should I do if I exposed my token?", "Rotate or replace the Account API Token in Bunpro, then update or recreate the protected credential in every MCP client where you configured it."]
@@ -478,8 +498,8 @@ function footer(): string {
   return `<footer class="site-footer">
     <div class="shell footer-grid">
       <div class="footer-brand"><a class="brand" href="#top"><span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span><span class="brand-copy"><strong>Bunpro MCP</strong><small>UNOFFICIAL COMMUNITY TOOL</small></span></a><p>Ask better questions about your Bunpro studies, with a connection that can read your data but never change it.</p></div>
-      <div><b>Explore</b><a href="#possibilities">What it does</a><a href="#tools">Tools</a><a href="#setup">Setup guide</a><a href="#help">Troubleshooting</a></div>
-      <div><b>Trust</b><a href="#privacy">Privacy</a><a href="#privacy">Security boundary</a><a href="#help">Health and help</a><a href="${OPENAI_MCP_GUIDE_URL}" target="_blank" rel="noreferrer">OpenAI MCP guide ${icon("external")}</a></div>
+      <div><b>Explore</b><a href="#possibilities">What it does</a><a href="#tools">Tools</a><a href="#setup">Setup guide</a><a href="#self-host">Self-host</a><a href="#help">Troubleshooting</a></div>
+      <div><b>Open source</b><a href="${SOURCE_REPOSITORY_URL}" target="_blank" rel="noreferrer">GitHub repository ${icon("external")}</a><a href="${SELF_HOSTING_GUIDE_URL}" target="_blank" rel="noreferrer">Self-hosting guide ${icon("external")}</a><a href="#privacy">Privacy and trust</a><a href="${OPENAI_MCP_GUIDE_URL}" target="_blank" rel="noreferrer">OpenAI MCP guide ${icon("external")}</a></div>
     </div>
     <div class="shell footer-bottom"><span>© ${new Date().getUTCFullYear()} Bunpro MCP community project</span><span>Not affiliated with Bunpro or OpenAI.</span><a href="#top">Back to top ↑</a></div>
   </footer>`;
@@ -738,6 +758,18 @@ function styles(): string {
     .auth-fallback p { margin: 7px 0 0; color: rgba(255,255,255,.62); font-size: 12px; line-height: 1.65; }
     .auth-fallback code { color: white; font-size: 11px; }
 
+    .open-source { background: var(--paper-light); border-bottom: 1px solid var(--line); }
+    .source-grid { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); }
+    .source-card { min-height: 350px; padding: 32px; display: flex; flex-direction: column; border-right: 1px solid var(--line); background: rgba(255,255,255,.18); }
+    .source-card:last-child { border-right: 0; }
+    .source-card > span { width: 46px; height: 46px; display: grid; place-items: center; color: var(--red); border: 1px solid var(--line); }
+    .source-card > small { margin-top: 28px; color: var(--red); font: 800 8px/1 var(--mono); letter-spacing: .12em; }
+    .source-card h3 { margin: 14px 0 12px; font: 400 29px/1.1 var(--serif); }
+    .source-card p { color: var(--muted); font-size: 13px; }
+    .source-actions { background: var(--paper-deep); }
+    .source-actions > div { margin-top: auto; display: flex; align-items: center; flex-wrap: wrap; gap: 14px; }
+    .source-actions .inline-link { color: var(--red); }
+
     .tools { background: var(--paper); }
     .tool-grid { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--line); }
     .tool-card { min-height: 360px; padding: 27px; display: flex; flex-direction: column; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: rgba(255,255,255,.17); }
@@ -815,6 +847,7 @@ function styles(): string {
     summary i::after { transform: rotate(90deg); transition: transform .2s; }
     details[open] summary i::after { transform: rotate(0); }
     details > p { padding: 0 44px 24px 2px; margin: 0; color: var(--muted); font-size: 14px; }
+    .faq .inline-link { color: var(--red); }
 
     .closing { padding-block: 96px; background: var(--red); color: white; overflow: hidden; }
     .closing-inner { min-height: 280px; display: grid; grid-template-columns: 1fr auto; gap: 80px; align-items: center; position: relative; }
@@ -884,6 +917,9 @@ function styles(): string {
       .use-case-grid { grid-template-columns: 1fr; }
       .use-case { min-height: 330px; border-right: 0; border-bottom: 1px solid var(--line); }
       .use-case:last-child { border-bottom: 0; }
+      .source-grid { grid-template-columns: 1fr; }
+      .source-card { min-height: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+      .source-card:last-child { border-bottom: 0; }
       .explainer-copy { max-width: 630px; }
       .setup-heading { align-items: start; }
       .connection-panel { position: relative; top: auto; max-width: 620px; justify-self: center; width: 100%; }

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ export function createServer(
   clientFactory: BunproClientFactory = () => new BunproClient(apiTokenFromEnvironment()),
   clock: Clock = () => new Date()
 ): McpServer {
-  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.3.1" });
+  const server = new McpServer({ name: "bunpro-mcp-server", version: "0.4.0" });
   let sharedClient: BunproAccountAccess | undefined;
   const getClient = (): BunproAccountAccess => {
     sharedClient ??= clientFactory();

--- a/tests/http-service.test.ts
+++ b/tests/http-service.test.ts
@@ -71,10 +71,12 @@ test("the public HTTP service enforces its canonical host and bounded MCP reques
     assert.match(homepage.body, /Leave blank/);
     assert.match(homepage.body, /Check my Bunpro connection/);
     assert.match(homepage.body, /source code public/);
-    assert.match(homepage.body, /source repository remains private/);
-    assert.match(homepage.body, /Can I clone or self-host it/);
-    assert.match(homepage.body, /Public self-hosting is not available/);
+    assert.match(homepage.body, /open source under the MIT license/);
+    assert.match(homepage.body, /Can I run it myself/);
+    assert.match(homepage.body, /Self-hosting guide/);
+    assert.match(homepage.body, /github\.com\/yash-278\/bunpro-mcp/);
     assert.doesNotMatch(homepage.body, /Available in ChatGPT|Open in ChatGPT|data-concept=/);
+    assert.doesNotMatch(homepage.body, /repository remains private|public self-hosting is not available/i);
     assert.doesNotMatch(homepage.body, /dangerously_authenticate|\/api\/frontend|Token token=/);
 
     const legacyConceptQuery = await request(service.port, "/?concept=orbit");


### PR DESCRIPTION
Bunpro approved making the read-only MCP open source. This release removes the obsolete private-source restriction, adds complete public README and self-hosting guidance, updates the website and FAQ with GitHub/local/Docker options, and records the public-release safety boundary.\n\nVerification: npm run check (34/34), npm audit --omit=dev (0 vulnerabilities), config parsing, credential/history scan, and responsive browser checks at desktop, 375px mobile, and landscape. Docker Desktop was unavailable locally; Railway will perform the deployment build after merge.